### PR TITLE
Admin menu ordering

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -118,6 +118,19 @@ instance running on the same machine as your app, you can::
     admin.add_view(rediscli.RedisCli(Redis()))
 
 
+Controling The Sort Order of The Admin Menu Links
+--------------------------------
+
+****
+
+The `menu_order` attribute of any admin view allows you to specify an integer that would be used to sort links in the admin menu regardless of the order of view registration.
+The typical usage of this attribute is to pass it as a keyword argument when initializing your admin views.
+Suppose you want to register an admin view called `MyView`, and you want it to be listed first,
+then you should give it a sufficiently large `menu_order`::
+
+    admin.add_view(MyView("myview", endpoint=".myview", menu_order=500))
+
+
 Replacing Individual Form Fields
 --------------------------------
 

--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -504,7 +504,7 @@ class Admin(object):
                 A dict of category names as keys and html classes as values to be added to menu category icons.
                 Example: {'Favorites': 'glyphicon glyphicon-star'}
             :param category_menu_orders:
-                A dict of category names as keys and integer ordering keys as values to be used for sorting categories in the menu.
+                A dict of category names as keys and sort keys as values for ordering this view in the menu.
                 Example: {'First Category': 200}
         """
         self.app = app

--- a/flask_admin/base.py
+++ b/flask_admin/base.py
@@ -1,4 +1,3 @@
-import math
 import os.path as op
 import warnings
 
@@ -443,7 +442,7 @@ class AdminIndexView(BaseView):
                  menu_class_name=None,
                  menu_icon_type=None,
                  menu_icon_value=None,
-                 menu_order=math.inf):
+                 menu_order=99999):
         super(AdminIndexView, self).__init__(name or babel.lazy_gettext('Home'),
                                              category,
                                              endpoint or 'admin',

--- a/flask_admin/contrib/mongoengine/view.py
+++ b/flask_admin/contrib/mongoengine/view.py
@@ -226,7 +226,8 @@ class ModelView(BaseModelView):
 
     def __init__(self, model, name=None,
                  category=None, endpoint=None, url=None, static_folder=None,
-                 menu_class_name=None, menu_icon_type=None, menu_icon_value=None):
+                 menu_class_name=None, menu_icon_type=None,
+                 menu_icon_value=None, menu_order=0):
         """
             Constructor
 
@@ -252,13 +253,16 @@ class ModelView(BaseModelView):
 
             :param menu_icon_value:
                 Icon glyph name or URL, depending on `menu_icon_type` setting
+            :param menu_order:
+                An integer that determines the order of this view in the menu
         """
         self._search_fields = []
 
         super(ModelView, self).__init__(model, name, category, endpoint, url, static_folder,
                                         menu_class_name=menu_class_name,
                                         menu_icon_type=menu_icon_type,
-                                        menu_icon_value=menu_icon_value)
+                                        menu_icon_value=menu_icon_value,
+                                        menu_order=menu_order)
 
         self._primary_key = self.scaffold_pk()
 

--- a/flask_admin/contrib/peewee/view.py
+++ b/flask_admin/contrib/peewee/view.py
@@ -162,13 +162,15 @@ class ModelView(BaseModelView):
 
     def __init__(self, model, name=None,
                  category=None, endpoint=None, url=None, static_folder=None,
-                 menu_class_name=None, menu_icon_type=None, menu_icon_value=None):
+                 menu_class_name=None, menu_icon_type=None,
+                 menu_icon_value=None, menu_order=0):
         self._search_fields = []
 
         super(ModelView, self).__init__(model, name, category, endpoint, url, static_folder,
                                         menu_class_name=menu_class_name,
                                         menu_icon_type=menu_icon_type,
-                                        menu_icon_value=menu_icon_value)
+                                        menu_icon_value=menu_icon_value,
+                                        menu_order=menu_order)
 
         self._primary_key = self.scaffold_pk()
 

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -284,7 +284,8 @@ class ModelView(BaseModelView):
 
     def __init__(self, model, session,
                  name=None, category=None, endpoint=None, url=None, static_folder=None,
-                 menu_class_name=None, menu_icon_type=None, menu_icon_value=None):
+                 menu_class_name=None, menu_icon_type=None,
+                 menu_icon_value=None, menu_order=0):
         """
             Constructor.
 
@@ -311,6 +312,8 @@ class ModelView(BaseModelView):
                  - `flask_admin.consts.ICON_TYPE_IMAGE_URL` - Image with full URL
             :param menu_icon_value:
                 Icon glyph name or URL, depending on `menu_icon_type` setting
+            :param menu_order:
+                An integer that determines the order of this view in the menu
         """
         self.session = session
 
@@ -326,7 +329,8 @@ class ModelView(BaseModelView):
         super(ModelView, self).__init__(model, name, category, endpoint, url, static_folder,
                                         menu_class_name=menu_class_name,
                                         menu_icon_type=menu_icon_type,
-                                        menu_icon_value=menu_icon_value)
+                                        menu_icon_value=menu_icon_value,
+                                        menu_order=menu_order)
 
         # Primary key
         self._primary_key = self.scaffold_pk()

--- a/flask_admin/menu.py
+++ b/flask_admin/menu.py
@@ -1,3 +1,4 @@
+from operator import attrgetter
 from flask import url_for
 
 
@@ -5,12 +6,13 @@ class BaseMenu(object):
     """
         Base menu item
     """
-    def __init__(self, name, class_name=None, icon_type=None, icon_value=None, target=None):
+    def __init__(self, name, class_name=None, icon_type=None, icon_value=None, target=None, sort_order=None):
         self.name = name
         self.class_name = class_name if class_name is not None else ''
         self.icon_type = icon_type
         self.icon_value = icon_value
         self.target = target
+        self.sort_order = sort_order
 
         self.parent = None
         self._children = []
@@ -19,6 +21,7 @@ class BaseMenu(object):
         # TODO: Check if menu item is already assigned to some parent
         menu.parent = self
         self._children.append(menu)
+        self._children.sort(key=attrgetter("sort_order"), reverse=True)
 
     def get_url(self):
         raise NotImplementedError()
@@ -85,7 +88,8 @@ class MenuView(BaseMenu):
         super(MenuView, self).__init__(name,
                                        class_name=view.menu_class_name,
                                        icon_type=view.menu_icon_type,
-                                       icon_value=view.menu_icon_value)
+                                       icon_value=view.menu_icon_value,
+                                       sort_order=view.menu_order)
 
         self._view = view
         self._cache = cache
@@ -131,8 +135,8 @@ class MenuLink(BaseMenu):
         Link item
     """
     def __init__(self, name, url=None, endpoint=None, category=None, class_name=None,
-                 icon_type=None, icon_value=None, target=None):
-        super(MenuLink, self).__init__(name, class_name, icon_type, icon_value, target)
+                 icon_type=None, icon_value=None, target=None, sort_order=None):
+        super(MenuLink, self).__init__(name, class_name, icon_type, icon_value, target, sort_order)
 
         self.category = category
 

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -774,7 +774,8 @@ class BaseModelView(BaseView, ActionsMixin):
 
     def __init__(self, model,
                  name=None, category=None, endpoint=None, url=None, static_folder=None,
-                 menu_class_name=None, menu_icon_type=None, menu_icon_value=None):
+                 menu_class_name=None, menu_icon_type=None,
+                 menu_icon_value=None, menu_order=0):
         """
             Constructor.
 
@@ -799,6 +800,8 @@ class BaseModelView(BaseView, ActionsMixin):
                  - `flask_admin.consts.ICON_TYPE_IMAGE_URL` - Image with full URL
             :param menu_icon_value:
                 Icon glyph name or URL, depending on `menu_icon_type` setting
+            :param menu_order:
+                An integer that determines the order of this view in the menu
         """
         self.model = model
 
@@ -809,7 +812,8 @@ class BaseModelView(BaseView, ActionsMixin):
         super(BaseModelView, self).__init__(name, category, endpoint, url, static_folder,
                                             menu_class_name=menu_class_name,
                                             menu_icon_type=menu_icon_type,
-                                            menu_icon_value=menu_icon_value)
+                                            menu_icon_value=menu_icon_value,
+                                            menu_order=menu_order)
 
         # Actions
         self.init_actions()

--- a/flask_admin/tests/test_base.py
+++ b/flask_admin/tests/test_base.py
@@ -1,4 +1,3 @@
-import math
 import os
 
 from nose.tools import ok_, eq_, raises
@@ -233,7 +232,7 @@ def test_menu_order():
     view_no_order = MockView(endpoint='test_no_order')
     admin.add_view(view_no_order)
     eq_(admin._menu[-1].sort_order, 0)
-    ok_(admin._menu[0].sort_order is math.inf)
+    eq_(admin._menu[0].sort_order, 99999)
 
     view1 = MockView(endpoint='test1', menu_order=20)
     view2 = MockView(endpoint='test2', menu_order=30)

--- a/flask_admin/tests/test_base.py
+++ b/flask_admin/tests/test_base.py
@@ -252,14 +252,8 @@ def test_menu_order():
     admin.add_link(base.MenuLink('Link2', endpoint='.link2', sort_order=110))
     eq_(admin._menu_links[0].name, "Link2")
 
-    admin.add_link(base.MenuLink('LinkWithCategory1',
-            endpoint='.linkcat1',
-            category=catname,
-            sort_order=200))
-    admin.add_link(base.MenuLink('LinkWithCategory2',
-        endpoint='.linkcat2',
-        category=catname,
-        sort_order=220))
+    admin.add_link(base.MenuLink('LinkWithCategory1', endpoint='.linkcat1', category=catname, sort_order=200))
+    admin.add_link(base.MenuLink('LinkWithCategory2', endpoint='.linkcat2', category=catname, sort_order=220))
     children = admin._menu[1].get_children()
     eq_(children[0].name, "LinkWithCategory2")
 


### PR DESCRIPTION
Hello,

Currently Flask-Admin doesn't provide a way to order the links in the admin menu.
However, such a feature is  extremely important for admin interfaces targeting non-developers as well as libraries built on top of Flask Admin (such as [Oy Content Management System](https://github.com/mush42/oy-cms).

This PR addresses this issue by adding two new attributes as follows:
- *sort_order* to `flask_admin.menu.BaseMenu` and all its subclasses  (default to None).
- *menu_order* to `flask_admin.base.BaseView` and
`flask_admin.model.base.BaseModelView` and all their subclasses (defaults to 0)

Based on these attributes the `BaseView.()_menu` attribute is sorted every time a new view is added using `BaseView.add_view`.

For menu links added using `BaseView.add_link`, the `BaseView._menu_link* is also sorted whenever a new link is added.

For menu categories, the user can specify category orders on the `BaseView.category_menu_orders` dictionary the same way they specify `category_icon_classes`. In this case the `category._children` list is also sorted whenever a new child is added to the category.