### PR TITLE
Remove extra call to `self._get_path`

### DIFF
--- a/flask_admin/form/upload.py
+++ b/flask_admin/form/upload.py
@@ -437,7 +437,7 @@ class ImageUploadField(FileUploadField):
             self._save_image(image, self._get_path(filename), format)
         else:
             data.seek(0)
-            data.save(self._get_path(filename))
+            data.save(path)
 
         self._save_thumbnail(data, filename, format)
 


### PR DESCRIPTION
I've noticed, that `self._get_path` is already evaluated at the beginning of the method, so it's not necessary to call it again.