### PR TITLE
AdminModelConverter should not filter out primary keys

### DIFF
--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -170,7 +170,7 @@ class AdminModelConverter(ModelConverterBase):
             form_columns = getattr(self.view, 'form_columns', None) or ()
 
             # Do not display foreign keys - use relations, except when explicitly instructed
-            if column.foreign_keys and prop.key not in form_columns:
+            if column.foreign_keys and not column.primary_key and prop.key not in form_columns:
                 return None
 
             # Only display "real" columns


### PR DESCRIPTION
If the primary key is also part of a foreign key, it would be filtered out and the form would fail to render.