### PR TITLE
Fix value of `desc` param in filter form (`1` instead of `"True"`)

### DIFF
--- a/flask_admin/templates/bootstrap2/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap2/admin/model/layout.html
@@ -41,7 +41,7 @@
         <input type="hidden" name="sort" value="{{ sort_column }}">
         {% endif %}
         {% if sort_desc %}
-        <input type="hidden" name="desc" value="{{ sort_desc }}">
+        <input type="hidden" name="desc" value="1">
         {% endif %}
         {% if search %}
         <input type="hidden" name="search" value="{{ search }}">
@@ -76,7 +76,7 @@
     <input type="hidden" name="sort" value="{{ sort_column }}">
     {% endif %}
     {% if sort_desc %}
-    <input type="hidden" name="desc" value="{{ sort_desc }}">
+    <input type="hidden" name="desc" value="1">
     {% endif %}
     {%- set full_search_placeholder = _gettext('Search') %}
     {%- if search_placeholder %}{% set full_search_placeholder = [full_search_placeholder, search_placeholder] | join(": ") %}{% endif %}

--- a/flask_admin/templates/bootstrap3/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap3/admin/model/layout.html
@@ -41,7 +41,7 @@
         <input type="hidden" name="sort" value="{{ sort_column }}">
         {% endif %}
         {% if sort_desc %}
-        <input type="hidden" name="desc" value="{{ sort_desc }}">
+        <input type="hidden" name="desc" value="1">
         {% endif %}
         {% if search %}
         <input type="hidden" name="search" value="{{ search }}">
@@ -76,7 +76,7 @@
     <input type="hidden" name="sort" value="{{ sort_column }}">
     {% endif %}
     {% if sort_desc %}
-    <input type="hidden" name="desc" value="{{ sort_desc }}">
+    <input type="hidden" name="desc" value="1">
     {% endif %}
     {%- set full_search_placeholder = _gettext('Search') %}
     {%- set max_size = config.get('FLASK_ADMIN_SEARCH_SIZE_MAX', 100) %}

--- a/flask_admin/templates/bootstrap4/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap4/admin/model/layout.html
@@ -34,7 +34,7 @@
             <input type="hidden" name="sort" value="{{ sort_column }}">
         {% endif %}
         {% if sort_desc %}
-            <input type="hidden" name="desc" value="{{ sort_desc }}">
+            <input type="hidden" name="desc" value="1">
         {% endif %}
         {% if search %}
             <input type="hidden" name="search" value="{{ search }}">
@@ -69,7 +69,7 @@
             <input type="hidden" name="sort" value="{{ sort_column }}">
         {% endif %}
         {% if sort_desc %}
-            <input type="hidden" name="desc" value="{{ sort_desc }}">
+            <input type="hidden" name="desc" value="1">
         {% endif %}
         {% if search %}
             <div class="form-inline input-group">


### PR DESCRIPTION
Fixes #1761

"hardcoding" `1` might seem bad, but since it's within the `if sort_desc` conditional, it should be fine. Though it could be replaced by something like `{{ 1 if sort_desc else 0 }}` for extra robustness.
