### PR TITLE
fix: example code for sqla-custom-inline-forms

### DIFF
--- a/examples/sqla-custom-inline-forms/app.py
+++ b/examples/sqla-custom-inline-forms/app.py
@@ -127,7 +127,8 @@ if __name__ == '__main__':
     admin.add_view(LocationAdmin())
 
     # Create DB
-    db.create_all()
+    with app.app_context():
+        db.create_all()
 
     # Start app
     app.run(debug=True)

--- a/examples/sqla-custom-inline-forms/requirements.txt
+++ b/examples/sqla-custom-inline-forms/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-Admin
 Flask-SQLAlchemy
-WTForms==1.0.5
+WTForms


### PR DESCRIPTION
Update example code for sqla-custom-inline-forms.

- Fix import error due to WTForms version outdated
- Fix out of flask app context error for `db.create_all()`