### PR TITLE
Stop using Docker for flake8 and sphinx, and test minimum requirements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,17 +8,12 @@ on:
       - master
 
 jobs:
-  test-job:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         tox-env: [py]
-        include:
-          - python-version: '3.x'
-            tox-env: flake8
-          - python-version: '3.x'
-            tox-env: docs-html
     services:
       # Label used to access the service container
       postgres:
@@ -64,4 +59,21 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tests
+        run: tox -e ${{ matrix.tox-env }}
+  checks:
+    name: ${{ matrix.tox-env }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tox-env: [flake8, docs-html]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install tox
+        run: pip install tox
+      - name: Run ${{ matrix.tox-env }}
         run: tox -e ${{ matrix.tox-env }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        tox-version: [ 'WTForms2' ]
+        tox-env: [ 'WTForms2' ]
         include:
           - python-version: 3.11
-            tox-version: flake8
+            tox-env: flake8
           - python-version: 3.11
-            tox-version: docs-html
+            tox-env: docs-html
     services:
       # Label used to access the service container
       postgres:
@@ -64,4 +64,4 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tests
-        run: tox -e ${{ matrix.tox-version }}
+        run: tox -e ${{ matrix.tox-env }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         tox-env: [ 'WTForms2' ]
         include:
-          - python-version: 3.11
+          - python-version: '3.x'
             tox-env: flake8
-          - python-version: 3.11
+          - python-version: '3.x'
             tox-env: docs-html
     services:
       # Label used to access the service container

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        tox-env: [ 'WTForms2' ]
+        tox-env: [py]
         include:
           - python-version: '3.x'
             tox-env: flake8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Run tests
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         tox-env: [py]
+        include:
+          - python-version: '3.7'
+            tox-env: minreqs
     services:
       # Label used to access the service container
       postgres:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-flake8
 Flask<2.0.0
 werkzeug<2.0.0
 sqlalchemy<2.0
@@ -15,8 +14,6 @@ flask-babelex
 shapely==1.5.9
 geoalchemy2
 psycopg2
-pytest
-pytest-cov
 sqlalchemy-citext
 sqlalchemy-utils>=0.36.6
 azure-storage-blob

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ geoalchemy2
 psycopg2
 sqlalchemy-citext
 sqlalchemy-utils>=0.36.6
-azure-storage-blob
+azure-storage-blob<12
 arrow<0.14.0
 colour
 email-validator

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,3 +25,4 @@ wtforms==2.3.3
 itsdangerous<2.1.0
 # flask-babelex
 Babel<=2.9.1
+pytz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ flake8
 Flask<2.0.0
 werkzeug<2.0.0
 sqlalchemy<2.0
-itsdangerous<2.1.0
 MarkupSafe<2.1.0
 jinja2<=3.0.0
 Flask-SQLAlchemy<3.0.0
@@ -12,7 +11,6 @@ mongoengine<=0.21.0
 pymongo>=3.7.0
 flask-mongoengine==0.8.2
 pillow>=3.3.2
-Babel<=2.9.1
 flask-babelex
 shapely==1.5.9
 geoalchemy2
@@ -26,3 +24,7 @@ arrow<0.14.0
 colour
 email-validator
 wtforms==2.3.3
+# flask < 2
+itsdangerous<2.1.0
+# flask-babelex
+Babel<=2.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,8 +19,6 @@ geoalchemy2
 psycopg2
 pytest
 pytest-cov
-coveralls
-pylint
 sqlalchemy-citext
 sqlalchemy-utils>=0.36.6
 azure-storage-blob

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,9 +2,9 @@ Flask==1.1.1
 werkzeug==0.16.1
 sqlalchemy==1.4.18
 MarkupSafe==1.1.0
-jinja2==2.10.1
+jinja2==2.11.3
 Flask-SQLAlchemy==2.5.0
-peewee==3.7.0
+peewee==3.8.0
 wtf-peewee==3.0.0
 mongoengine==0.20.0
 pymongo==3.7.0
@@ -13,7 +13,7 @@ pillow==9.1.0
 flask-babelex==0.9.3
 shapely==1.5.9
 geoalchemy2==0.6.3
-psycopg2==2.8.4
+psycopg2==2.8.6
 sqlalchemy-citext==1.5-0
 sqlalchemy-utils==0.37.0
 azure-storage-blob==1.4.0

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -25,3 +25,4 @@ wtforms==2.2
 itsdangerous==2.0.1
 # flask-babelex
 Babel==2.9.1
+pytz

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,27 @@
+Flask==1.1.1
+werkzeug==0.16.1
+sqlalchemy==1.3.12
+MarkupSafe==1.1.0
+jinja2==2.10.1
+Flask-SQLAlchemy==2.1
+peewee==3.7.0
+wtf-peewee==3.0.0
+mongoengine==0.20.0
+pymongo==3.7.0
+flask-mongoengine==0.8.2
+pillow==9.1.0
+flask-babelex==0.9.3
+shapely==1.5.9
+geoalchemy2==0.6.3
+psycopg2==2.8.4
+sqlalchemy-citext==1.5-0
+sqlalchemy-utils==0.36.6
+azure-storage-blob==1.4.0
+arrow==0.13.2
+colour==0.1.5
+email-validator==1.1.2
+wtforms==2.2
+# flask
+itsdangerous==2.0.1
+# flask-babelex
+Babel==2.9.1

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,9 +1,9 @@
 Flask==1.1.1
 werkzeug==0.16.1
-sqlalchemy==1.3.12
+sqlalchemy==1.4.18
 MarkupSafe==1.1.0
 jinja2==2.10.1
-Flask-SQLAlchemy==2.1
+Flask-SQLAlchemy==2.5.0
 peewee==3.7.0
 wtf-peewee==3.0.0
 mongoengine==0.20.0
@@ -15,7 +15,7 @@ shapely==1.5.9
 geoalchemy2==0.6.3
 psycopg2==2.8.4
 sqlalchemy-citext==1.5-0
-sqlalchemy-utils==0.36.6
+sqlalchemy-utils==0.37.0
 azure-storage-blob==1.4.0
 arrow==0.13.2
 colour==0.1.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py
+    minreqs
     flake8
     docs-html
 skipsdist = true
@@ -15,7 +16,8 @@ setenv =
     AZURE_STORAGE_CONNECTION_STRING = DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 usedevelop = true
 deps =
-    -r requirements-dev.txt
+    !minreqs: -r requirements-dev.txt
+    minreqs: -r requirements-min.txt
     pytest
     pytest-cov
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    WTForms{1,2}
-    py38-WTForms2
+    py
     flake8
     docs-html
 skipsdist = true
@@ -16,8 +15,6 @@ setenv =
     AZURE_STORAGE_CONNECTION_STRING = DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 usedevelop = true
 deps =
-    WTForms1: WTForms==1.0.5
-    WTForms2: WTForms>=2.0
     -r requirements-dev.txt
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ deps =
     WTForms1: WTForms==1.0.5
     WTForms2: WTForms>=2.0
     -r requirements-dev.txt
+    pytest
+    pytest-cov
 commands =
     pytest -v flask_admin/tests --cov=flask_admin --cov-report=html
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest -v flask_admin/tests --cov=flask_admin --cov-report=html
+    pytest -vra flask_admin/tests --cov=flask_admin --cov-report=html
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
A few different things here. Happy to split up. Notably:

- WTForms 1 was not being tested anyway, requirements-dev.txt has wtforms==2.3.3
- Save installing the database containers for flake8 and doc-html
- Test the minimum version of requirements: excercise the current compatibilty code and support maintaining existing versions while enabling newer versions. e.g. this would allow testing WTForms 2 and 3.
Where there wasn't version information in requirements-dev.txt I picked versions that are, or could have been, in Ubuntu 20.04 and then tweaked a few to get them working together (see commit message). Clearly versions could be further adjusted.
