### PR TITLE
Fix exceptions when flask-babel is installed but not used

### DIFF
--- a/flask_admin/babel.py
+++ b/flask_admin/babel.py
@@ -1,10 +1,17 @@
+from flask import current_app, has_app_context
+
 try:
     try:
         from flask_babelex import Domain
     except ImportError:
         from flask_babel import Domain
 
-except ImportError:
+    if has_app_context():
+        current_app().extensions['babel']
+    else:
+        raise KeyError
+
+except (KeyError, ImportError):
     def gettext(string, **variables):
         return string % variables
 

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -7,7 +7,11 @@ from flask_admin.form.fields import Select2Field, DateTimeField
 from flask_admin._compat import as_unicode
 from flask_admin._compat import iteritems
 from flask_admin.contrib.sqla import ModelView, filters, tools
-from flask_babelex import Babel
+
+try:
+    from flask_babelex import Babel
+except ImportError:
+    from flask_babel import Babel
 
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy import cast

--- a/flask_admin/tests/sqla/test_translation.py
+++ b/flask_admin/tests/sqla/test_translation.py
@@ -1,5 +1,9 @@
 from flask_admin.babel import lazy_gettext
-from flask_babelex import Babel
+
+try:
+    from flask_babelex import Babel
+except ImportError:
+    from flask_babel import Babel
 
 from . import setup
 from .test_basic import CustomModelView, create_models

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pymongo>=3.7.0
 flask-mongoengine==0.8.2
 pillow>=3.3.2
 Babel<=2.9.1
-flask-babelex
+flask-babel
 shapely==1.5.9
 geoalchemy2
 psycopg2


### PR DESCRIPTION
flask-babel's gettext() expects a Babel object to have been created.

Otherwise an exception is raised. For an example see tests/test_form_upload.py

---

I think this illustrates the problem. Not clear that it is the correct fix.
