### PR TITLE
WTForms 3.1.0 expanded SelectField choices parameter

### DIFF
--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -95,10 +95,10 @@ class QuerySelectField(SelectFieldBase):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield (u'__None', self.blank_text, self.data is None)
+            yield (u'__None', self.blank_text, self.data is None, {})
 
         for pk, obj in self._get_object_list():
-            yield (pk, self.get_label(obj), obj == self.data)
+            yield (pk, self.get_label(obj), obj == self.data, {})
 
     def process_formdata(self, valuelist):
         if valuelist:

--- a/flask_admin/contrib/sqla/widgets.py
+++ b/flask_admin/contrib/sqla/widgets.py
@@ -20,7 +20,7 @@ class CheckboxListInput:
 
     def __call__(self, field, **kwargs):
         items = []
-        for val, label, selected in field.iter_choices():
+        for val, label, selected, render_kw in field.iter_choices():
             args = {
                 'id': val,
                 'name': field.name,

--- a/flask_admin/form/fields.py
+++ b/flask_admin/form/fields.py
@@ -119,13 +119,13 @@ class Select2Field(fields.SelectField):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield (u'__None', self.blank_text, self.data is None)
+            yield (u'__None', self.blank_text, self.data is None, {})
 
         for choice in self.choices:
             if isinstance(choice, tuple):
-                yield (choice[0], choice[1], self.coerce(choice[0]) == self.data)
+                yield (choice[0], choice[1], self.coerce(choice[0]) == self.data, {})
             else:
-                yield (choice.value, choice.name, self.coerce(choice.value) == self.data)
+                yield (choice.value, choice.name, self.coerce(choice.value) == self.data, {})
 
     def process_data(self, value):
         if value is None:

--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -158,7 +158,7 @@ class XEditableWidget(object):
 
             choices = []
             selected_ids = []
-            for value, label, selected in field.iter_choices():
+            for value, label, selected, render_kw in field.iter_choices():
                 try:
                     label = text_type(label)
                 except TypeError:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,4 +27,4 @@ azure-storage-blob
 arrow<0.14.0
 colour
 email-validator
-wtforms==2.3.3
+wtforms


### PR DESCRIPTION
```
  File "/home/runner/work/flask-admin/flask-admin/flask_admin/templates/bootstrap2/admin/lib.html", line 183, in template
    {{ render_field(form, f, kwargs) }}
  File "/home/runner/work/flask-admin/flask-admin/.tox/py/lib/python3.10/site-packages/jinja2/runtime.py", line 777, in _invoke
    rv = self._func(*arguments)
  File "/home/runner/work/flask-admin/flask-admin/flask_admin/templates/bootstrap2/admin/lib.html", line 137, in template
    {{ field(**kwargs)|safe }}
  File "/home/runner/work/flask-admin/flask-admin/.tox/py/lib/python3.10/site-packages/wtforms/fields/core.py", line 176, in __call__
    return self.meta.render_field(self, kwargs)
  File "/home/runner/work/flask-admin/flask-admin/.tox/py/lib/python3.10/site-packages/wtforms/meta.py", line 64, in render_field
    return field.widget(field, **render_kw)
  File "/home/runner/work/flask-admin/flask-admin/flask_admin/form/widgets.py", line 28, in __call__
    return super(Select2Widget, self).__call__(field, **kwargs)
  File "/home/runner/work/flask-admin/flask-admin/.tox/py/lib/python3.10/site-packages/wtforms/widgets/core.py", line 365, in __call__
    for val, label, selected, render_kw in field.iter_choices():
ValueError: not enough values to unpack (expected 4, got 3)
```
---

This is to illustrate the location of the problem for #2391. Clearly it doesn't allow you to use the new option from WTForms 3.1 and I expect it's going to break with WTForms < 3.1.
