### PR TITLE
Fixes #2406: Multiple requests are sent when opening create, edit, and detail modals due to repetitive load of `bs4_modal.js`

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/create.html
@@ -32,5 +32,4 @@
 {% endblock %}
 
 {% block tail %}
-  <script src="{{ admin_static.url(filename='admin/js/bs4_modal.js', v='1.0.0') }}"></script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/create.html
@@ -30,6 +30,3 @@
 
 
 {% endblock %}
-
-{% block tail %}
-{% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/details.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/details.html
@@ -35,4 +35,5 @@
 {% endblock %}
 
 {% block tail %}
+  <script src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/details.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/details.html
@@ -35,6 +35,4 @@
 {% endblock %}
 
 {% block tail %}
-  <script src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
-  <script src="{{ admin_static.url(filename='admin/js/bs4_modal.js', v='1.0.0') }}"></script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/edit.html
@@ -27,5 +27,4 @@
 {% endblock %}
 
 {% block tail %}
-  <script src="{{ admin_static.url(filename='admin/js/bs4_modal.js', v='1.0.0') }}"></script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/edit.html
@@ -25,6 +25,3 @@
   {% endcall %}
 
 {% endblock %}
-
-{% block tail %}
-{% endblock %}


### PR DESCRIPTION
Script tags that load `bs4_modal.js` in `templates/bootstrap4/admin/model/modals/create.html`, `templates/bootstrap4/admin/model/modals/edit.html`, and `templates/bootstrap4/admin/model/modals/details.html` template files are removed.

Fix: https://github.com/flask-admin/flask-admin/issues/2406