### PR TITLE
Add Flask `host_matching` support to admin instances

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -68,6 +68,55 @@ header to make the selection automatically.
 If the built-in translations are not enough, look at the `Flask-Babel documentation <https://pythonhosted.org/Flask-Babel/>`_
 to see how you can add your own.
 
+Using with Flask in `host_matching` mode
+----------------------------------------
+
+****
+
+If Flask is configured with `host_matching` enabled, then all routes registered on the app need to know which host(s) they should be served for.
+
+This requires some additional explicit configuration for Flask-Admin by passing the `host` argument to `Admin()` calls.
+
+#. With your Flask app initialised::
+
+        from flask import Flask
+        app = Flask(__name__, host='my.domain.com', static_host='static.domain.com')
+
+
+Serving Flask-Admin on a single, explicit host
+**********************************************
+Construct your Admin instance(s) and pass the desired `host` for the admin instance::
+
+        class AdminView(admin.BaseView):
+            @admin.expose('/')
+            def index(self):
+                return self.render('template.html')
+
+        admin1 = admin.Admin(app, url='/admin', host='admin.domain.com')
+        admin1.add_view(AdminView())
+
+Flask's `url_for` calls will work without any additional configuration/information::
+
+        url_for('admin.index', _external=True) == 'http://admin.domain.com/admin')
+
+
+Serving Flask-Admin on all hosts
+********************************
+Pass a wildcard to the `host` parameter to serve the admin instance on all hosts::
+
+        class AdminView(admin.BaseView):
+            @admin.expose('/')
+            def index(self):
+                return self.render('template.html')
+
+        admin1 = admin.Admin(app, url='/admin', host='*')
+        admin1.add_view(AdminView())
+
+If you need to generate URLs for a wildcard admin instance, you will need to pass `admin_routes_host` to the `url_for` call::
+
+        url_for('admin.index', admin_routes_host='admin.domain.com', _external=True) == 'http://admin.domain.com/admin')
+        url_for('admin.index', admin_routes_host='admin2.domain.com', _external=True) == 'http://admin2.domain.com/admin')
+
 .. _file-admin:
 
 Managing Files & Folders

--- a/examples/host-matching/README.rst
+++ b/examples/host-matching/README.rst
@@ -1,0 +1,21 @@
+This example shows how to configure Flask-Admin when you're using Flask's `host_matching` mode. Any Flask-Admin instance can be exposed on just a specific host, or on every host.
+
+To run this example:
+
+1. Clone the repository::
+
+    git clone https://github.com/flask-admin/flask-admin.git
+    cd flask-admin
+
+2. Create and activate a virtual environment::
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+
+3. Install requirements::
+
+    pip install -r 'examples/host-matching/requirements.txt'
+
+4. Run the application::
+
+    python examples/host-matching/app.py

--- a/examples/host-matching/app.py
+++ b/examples/host-matching/app.py
@@ -1,0 +1,55 @@
+from flask import Flask, url_for
+
+import flask_admin as admin
+
+
+# Views
+class FirstView(admin.BaseView):
+    @admin.expose('/')
+    def index(self):
+        return self.render('first.html')
+
+
+class SecondView(admin.BaseView):
+    @admin.expose('/')
+    def index(self):
+        return self.render('second.html')
+
+
+class ThirdViewAllHosts(admin.BaseView):
+    @admin.expose('/')
+    def index(self):
+        return self.render('third.html')
+
+
+# Create flask app
+app = Flask(__name__, template_folder='templates', host_matching=True, static_host='static.localhost:5000')
+
+
+# Flask views
+@app.route('/', host='<anyhost>')
+def index(anyhost):
+    return (
+        f'<a href="{url_for("admin.index")}">Click me to get to Admin 1</a>'
+        f'<br/>'
+        f'<a href="{url_for("admin2.index")}">Click me to get to Admin 2</a>'
+        f'<br/>'
+        f'<a href="{url_for("admin3.index", admin_routes_host="anything.localhost:5000")}">Click me to get to Admin 3 under `anything.localhost:5000`</a>'
+    )
+
+
+if __name__ == '__main__':
+    # Create first administrative interface at `first.localhost:5000/admin1`
+    admin1 = admin.Admin(app, url='/admin1', host='first.localhost:5000')
+    admin1.add_view(FirstView())
+
+    # Create second administrative interface at `second.localhost:5000/admin2`
+    admin2 = admin.Admin(app, url='/admin2', endpoint='admin2', host='second.localhost:5000')
+    admin2.add_view(SecondView())
+
+    # Create third administrative interface, available on any domain at `/admin3`
+    admin3 = admin.Admin(app, url='/admin3', endpoint='admin3', host='*')
+    admin3.add_view(ThirdViewAllHosts())
+
+    # Start app
+    app.run(debug=True)

--- a/examples/host-matching/requirements.txt
+++ b/examples/host-matching/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-Admin

--- a/examples/host-matching/templates/first.html
+++ b/examples/host-matching/templates/first.html
@@ -1,0 +1,4 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+    First admin view.
+{% endblock %}

--- a/examples/host-matching/templates/second.html
+++ b/examples/host-matching/templates/second.html
@@ -1,0 +1,4 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+    Second admin view.
+{% endblock %}

--- a/examples/host-matching/templates/third.html
+++ b/examples/host-matching/templates/third.html
@@ -1,0 +1,4 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+    Third admin view.
+{% endblock %}

--- a/flask_admin/blueprints.py
+++ b/flask_admin/blueprints.py
@@ -1,0 +1,59 @@
+import typing as t
+
+from flask import request, Flask
+from flask.blueprints import Blueprint as FlaskBlueprint
+from flask.blueprints import BlueprintSetupState as FlaskBlueprintSetupState
+
+from flask_admin.consts import ADMIN_ROUTES_HOST_VARIABLE_NAME, \
+    ADMIN_ROUTES_HOST_VARIABLE
+
+
+class _BlueprintSetupStateWithHostSupport(FlaskBlueprintSetupState):
+    """Adds the ability to set a hostname on all routes when registering the blueprint."""
+
+    def __init__(self, blueprint, app, options, first_registration):
+        super().__init__(blueprint, app, options, first_registration)
+        self.host = self.options.get("host")
+
+    def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
+        # Ensure that every route registered by this blueprint has the host parameter
+        options.setdefault("host", self.host)
+        super().add_url_rule(rule, endpoint, view_func, **options)
+
+
+class _BlueprintWithHostSupport(FlaskBlueprint):
+    def make_setup_state(self, app, options, first_registration=False):
+        return _BlueprintSetupStateWithHostSupport(
+            self, app, options, first_registration
+        )
+
+    def attach_url_defaults_and_value_preprocessor(self, app: Flask, host: str):
+        if host != ADMIN_ROUTES_HOST_VARIABLE:
+            return
+
+        # Automatically inject `admin_routes_host` into `url_for` calls on admin
+        # endpoints.
+        @self.url_defaults
+        def inject_admin_routes_host_if_required(
+            endpoint: str, values: t.Dict[str, t.Any]
+        ) -> None:
+            if app.url_map.is_endpoint_expecting(
+                endpoint, ADMIN_ROUTES_HOST_VARIABLE_NAME
+            ):
+                values.setdefault(ADMIN_ROUTES_HOST_VARIABLE_NAME, request.host)
+
+        # Automatically strip `admin_routes_host` from the endpoint values so
+        # that the view methods don't receive that parameter, as it's not actually
+        # required by any of them.
+        @self.url_value_preprocessor
+        def strip_admin_routes_host_from_static_endpoint(
+            endpoint: t.Optional[str], values: t.Optional[t.Dict[str, t.Any]]
+        ) -> None:
+            if (
+                endpoint
+                and values
+                and app.url_map.is_endpoint_expecting(
+                    endpoint, ADMIN_ROUTES_HOST_VARIABLE_NAME
+                )
+            ):
+                values.pop(ADMIN_ROUTES_HOST_VARIABLE_NAME, None)

--- a/flask_admin/consts.py
+++ b/flask_admin/consts.py
@@ -6,3 +6,7 @@ ICON_TYPE_FONT_AWESOME = 'fa'
 ICON_TYPE_IMAGE = 'image'
 # external image
 ICON_TYPE_IMAGE_URL = 'image-url'
+
+
+ADMIN_ROUTES_HOST_VARIABLE = "<admin_routes_host>"
+ADMIN_ROUTES_HOST_VARIABLE_NAME = "admin_routes_host"

--- a/flask_admin/tests/test_base.py
+++ b/flask_admin/tests/test_base.py
@@ -10,7 +10,7 @@ from flask_admin import base
 
 @pytest.fixture
 def app():
-    # Overrides the `app` fixture in `flask_admin/tests/conftest.py` so that the `sqla`
+    # Overrides the `app` fixture in `flask_admin/tests/conftest.py` so that the `tests`
     # directory/import path is configured as the root path for Flask. This will
     # cause the `templates` directory here to be used for template resolution.
     app = Flask(__name__)

--- a/flask_admin/tests/test_host_matching.py
+++ b/flask_admin/tests/test_host_matching.py
@@ -1,0 +1,209 @@
+import pytest
+from flask import Flask, url_for
+
+from flask_admin import base
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__, host_matching=True, static_host='static.test.localhost')
+    app.config['SECRET_KEY'] = '1'
+    app.config['WTF_CSRF_ENABLED'] = False
+
+    yield app
+
+
+def init_admin(app, using_init_app: bool, admin_kwargs):
+    if using_init_app:
+        admin = base.Admin(**admin_kwargs)
+        admin.init_app(app)
+    else:
+        admin = base.Admin(app, **admin_kwargs)
+
+    return admin
+
+
+class MockView(base.BaseView):
+    # Various properties
+    allow_call = True
+    allow_access = True
+    visible = True
+
+    @base.expose('/')
+    def index(self):
+        return 'Success!'
+
+    @base.expose('/test/')
+    def test(self):
+        return self.render('mock.html')
+
+    @base.expose('/base/')
+    def base(self):
+        return self.render('admin/base.html')
+
+    def _handle_view(self, name, **kwargs):
+        if self.allow_call:
+            return super(MockView, self)._handle_view(name, **kwargs)
+        else:
+            return 'Failure!'
+
+    def is_accessible(self):
+        if self.allow_access:
+            return super(MockView, self).is_accessible()
+
+        return False
+
+    def is_visible(self):
+        if self.visible:
+            return super(MockView, self).is_visible()
+
+        return False
+
+
+@pytest.mark.parametrize("initialise_using_init_app", [True, False])
+def test_mounting_on_host_with_variable_is_unsupported(app, babel, initialise_using_init_app):
+    with pytest.raises(ValueError) as e:
+        init_admin(
+            app,
+            using_init_app=initialise_using_init_app,
+            admin_kwargs=dict(url='/', host="<blah>"),
+        )
+
+    assert str(e.value) == (
+        "`host` must either be a host name with no variables, to serve all Flask-Admin "
+        "routes from a single host, or `*` to match the current request's host."
+    )
+
+
+@pytest.mark.parametrize("initialise_using_init_app", [True, False])
+def test_mounting_on_host_with_flask_mismatch(initialise_using_init_app):
+    app = Flask(__name__, host_matching=False)
+
+    with pytest.raises(ValueError) as e:
+        init_admin(
+            app=app,
+            using_init_app=initialise_using_init_app,
+            admin_kwargs=dict(url='/', host="host"),
+        )
+
+    assert str(e.value) == (
+        "`host` should only be set if your Flask app is using `host_matching`."
+    )
+
+
+@pytest.mark.parametrize("initialise_using_init_app", [True, False])
+def test_mounting_on_subdomain_and_host_is_rejected(
+    app, babel, initialise_using_init_app
+):
+    with pytest.raises(ValueError) as e:
+        init_admin(
+            app,
+            using_init_app=initialise_using_init_app,
+            admin_kwargs=dict(url='/', subdomain='subdomain', host="host"),
+        )
+
+    assert str(e.value) == "`subdomain` and `host` are mutually-exclusive"
+
+
+@pytest.mark.parametrize("initialise_using_init_app", [True, False])
+def test_mounting_on_host(app, babel, initialise_using_init_app):
+    admin = init_admin(
+        app,
+        using_init_app=initialise_using_init_app,
+        admin_kwargs=dict(url='/', host="admin.test.localhost"),
+    )
+    admin.add_view(MockView())
+
+    client = app.test_client()
+    rv = client.get('/mockview/')
+    assert rv.status_code == 404
+
+    rv = client.get('/mockview/', headers={"Host": "admin.test.localhost"})
+    assert rv.status_code == 200
+    assert rv.data == b'Success!'
+
+    client = app.test_client()
+    rv = client.get('/mockview/base/')
+    assert rv.status_code == 404
+
+    rv = client.get('/mockview/base/', headers={"Host": "admin.test.localhost"})
+    assert rv.status_code == 200
+
+    # Check that static assets are embedded with the expected (relative) URLs
+    assert (
+        b'<link href="/static/admin/bootstrap/bootstrap2/swatch'
+        b'/default/bootstrap.min.css?v=2.3.2" rel="stylesheet">'
+        in rv.data
+    )
+    assert (
+        b'<script src="/static/admin/vendor'
+        b'/jquery.min.js?v=3.5.1" type="text/javascript">'
+        in rv.data
+    )
+
+    # test static files when url='/'
+    with app.test_request_context('/', headers={"Host": "admin.test.localhost"}):
+        rv = client.get(
+            url_for(
+                'admin.static',
+                filename='bootstrap/bootstrap2/css/bootstrap.min.css',
+            )
+        )
+        rv.close()
+        assert rv.status_code == 404
+
+        rv = client.get(
+            url_for(
+                'admin.static',
+                filename='bootstrap/bootstrap2/css/bootstrap.min.css',
+            ),
+            headers={"Host": "admin.test.localhost"}
+        )
+        rv.close()
+        assert rv.status_code == 200
+
+
+@pytest.mark.parametrize("initialise_using_init_app", [True, False])
+def test_mounting_on_wildcard_host(app, babel, initialise_using_init_app):
+    admin = init_admin(
+        app,
+        using_init_app=initialise_using_init_app,
+        admin_kwargs=dict(url='/', host="*"),
+    )
+    admin.add_view(MockView())
+
+    client = app.test_client()
+
+    for host_header in [
+        {},
+        {"Host": "admin.test.localhost"},
+        {"Host": "absolutely.any.value"},
+    ]:
+        rv = client.get('/mockview/base/', headers=host_header)
+        rv.close()
+        assert rv.status_code == 200
+
+        # Check that static assets are embedded with the expected (relative) URLs
+        assert (
+            b'<link href="/static/admin/bootstrap/bootstrap2/swatch'
+            b'/default/bootstrap.min.css?v=2.3.2" '
+            b'rel="stylesheet">'
+            in rv.data
+        )
+        assert (
+            b'<script src="/static/admin/vendor'
+            b'/jquery.min.js?v=3.5.1" type="text/javascript">'
+            in rv.data
+        )
+
+        # test static files when url='/'
+        with app.test_request_context('/'):
+            rv = client.get(
+                url_for(
+                    'admin.static',
+                    filename='bootstrap/bootstrap2/css/bootstrap.min.css',
+                    headers=host_header,
+                ),
+            )
+            rv.close()
+            assert rv.status_code == 200


### PR DESCRIPTION
If Flask is running in `host_matching` mode, all routes need to be configured with a `host` that restricts resolution to only specific domains.

fixes: https://github.com/pallets-eco/flask-admin/issues/1395