### PR TITLE
Fix already exists translation

### DIFF
--- a/flask_admin/contrib/sqla/validators.py
+++ b/flask_admin/contrib/sqla/validators.py
@@ -4,6 +4,7 @@ from wtforms import ValidationError
 from wtforms.validators import InputRequired
 
 from flask_admin._compat import filter_list
+from flask_admin.babel import lazy_gettext
 
 
 class Unique(object):
@@ -24,7 +25,7 @@ class Unique(object):
         self.db_session = db_session
         self.model = model
         self.column = column
-        self.message = message
+        self.message = message or lazy_gettext('Already exists.')
 
     def __call__(self, form, field):
         # databases allow multiple NULL values for unique columns
@@ -37,9 +38,7 @@ class Unique(object):
                    .one())
 
             if not hasattr(form, '_obj') or not form._obj == obj:
-                if self.message is None:
-                    self.message = field.gettext(u'Already exists.')
-                raise ValidationError(self.message)
+                raise ValidationError(str(self.message))
         except NoResultFound:
             pass
 

--- a/flask_admin/tests/conftest.py
+++ b/flask_admin/tests/conftest.py
@@ -15,9 +15,10 @@ def app():
 
 @pytest.fixture
 def babel(app):
+    babel = None
     try:
         from flask_babel import Babel
-        _ = Babel(app)
+        babel = Babel(app)
     except ImportError:
         pass
 

--- a/flask_admin/tests/sqla/test_translation.py
+++ b/flask_admin/tests/sqla/test_translation.py
@@ -1,7 +1,8 @@
-from flask_admin.babel import lazy_gettext
+from flask_admin.babel import gettext
 
 from .test_basic import CustomModelView, create_models
 from .. import flask_babel_test_decorator
+from ...contrib.sqla import ModelView
 
 
 @flask_babel_test_decorator
@@ -17,7 +18,7 @@ def test_column_label_translation(request, app):
     with app.app_context():
         Model1, _ = create_models(db)
 
-        label = lazy_gettext('Name')
+        label = gettext('Name')
 
         view = CustomModelView(Model1, db.session,
                                column_list=['test1', 'test3'],
@@ -30,3 +31,31 @@ def test_column_label_translation(request, app):
         rv = client.get('/admin/model1/?flt1_0=test')
         assert rv.status_code == 200
         assert '{"Nombre":' in rv.data.decode('utf-8')
+
+
+@flask_babel_test_decorator
+def test_unique_validator_translation_is_dynamic(app, db, admin):
+    with app.app_context():
+        class UniqueTable(db.Model):
+            id = db.Column(db.Integer, primary_key=True)
+            value = db.Column(db.String, unique=True)
+
+        db.create_all()
+
+        view = ModelView(UniqueTable, db.session)
+        view.can_create = True
+        admin.add_view(view)
+
+        client = app.test_client()
+        rv = client.post('/admin/uniquetable/new', data=dict(id="1", value='hello'), follow_redirects=True)
+        assert rv.status_code == 200
+
+        rv = client.post('/admin/uniquetable/new', data=dict(id="1", value='hello'), follow_redirects=True)
+        assert rv.status_code == 200
+        assert "Already exists." in rv.text
+
+        from flask_babel import force_locale
+        with force_locale('fr'):
+            rv = client.post('/admin/uniquetable/new', data=dict(id="1", value='hello'), follow_redirects=True)
+            assert rv.status_code == 200
+            assert "Existe déjà." in rv.text

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,7 +29,7 @@ azure-storage-common==2.1.0
     # via
     #   -r typing.txt
     #   azure-storage-blob
-babel==2.9.1
+babel==2.15.0
     # via
     #   -r docs.txt
     #   -r tests.in
@@ -120,7 +120,7 @@ flask==2.1.3
     #   flask-mongoengine
     #   flask-sqlalchemy
     #   flask-wtf
-flask-babel==2.0.0
+flask-babel==4.0.0
     # via
     #   -r tests.in
     #   -r typing.txt
@@ -172,7 +172,7 @@ itsdangerous==2.0.1
     #   -r typing.txt
     #   flask
     #   flask-wtf
-jinja2==3.0.0
+jinja2==3.1.4
     # via
     #   -r docs.txt
     #   -r tests.in

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.13
     # via sphinx
-babel==2.9.1
+babel==2.15.0
     # via
     #   -c tests.in
     #   sphinx
@@ -22,7 +22,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.7.0
     # via sphinx
-jinja2==3.0.0
+jinja2==3.1.4
     # via
     #   -c tests.in
     #   sphinx

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -3,7 +3,7 @@ werkzeug
 sqlalchemy<2.0
 itsdangerous<2.1.0
 MarkupSafe<2.1.0
-jinja2<=3.0.0
+jinja2>=2.0.0
 Flask-SQLAlchemy<3.0.0
 peewee
 wtf-peewee
@@ -11,8 +11,8 @@ mongoengine
 pymongo>=3.7.0
 flask-mongoengine==0.8.2
 pillow>=3.3.2
-Babel<=2.9.1
-flask-babel
+Babel>=2.0.0
+flask-babel>=3.0.0
 shapely>=2
 geoalchemy2
 psycopg2

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -16,7 +16,7 @@ azure-storage-blob==2.1.0
     # via -r tests.in
 azure-storage-common==2.1.0
     # via azure-storage-blob
-babel==2.9.1
+babel==2.15.0
     # via
     #   -r tests.in
     #   flask-babel
@@ -56,7 +56,7 @@ flask==2.1.3
     #   flask-mongoengine
     #   flask-sqlalchemy
     #   flask-wtf
-flask-babel==2.0.0
+flask-babel==4.0.0
     # via -r tests.in
 flask-mongoengine==0.8.2
     # via -r tests.in
@@ -81,7 +81,7 @@ itsdangerous==2.0.1
     #   -r tests.in
     #   flask
     #   flask-wtf
-jinja2==3.0.0
+jinja2==3.1.4
     # via
     #   -r tests.in
     #   flask


### PR DESCRIPTION
There are two problems with the translation of this string:

1) We use WTForm's translation rather than Flask-Admin's, so the translation isn't found.
2) We cache the result of the first translation for the lifetime of the app. This means that if the user changes language dynamically, the message is not re-translated. By using `lazy_gettext` we can force the message to be translated every time the unique constraint is called.

fix: https://github.com/pallets-eco/flask-admin/issues/2108