### PR TITLE
Fix modal regression

### DIFF
--- a/examples/geo_alchemy/app.py
+++ b/examples/geo_alchemy/app.py
@@ -60,13 +60,17 @@ def index():
 # Create admin
 admin = admin.Admin(app, name='Example: GeoAlchemy', theme=Bootstrap4Theme())
 
+
+class ModalModelView(ModelView):
+    edit_modal = True
+
 # Add views
-admin.add_view(ModelView(Point, db.session, category='Points'))
-admin.add_view(ModelView(MultiPoint, db.session, category='Points'))
-admin.add_view(ModelView(Polygon, db.session, category='Polygons'))
-admin.add_view(ModelView(MultiPolygon, db.session, category='Polygons'))
-admin.add_view(ModelView(LineString, db.session, category='Lines'))
-admin.add_view(ModelView(MultiLineString, db.session, category='Lines'))
+admin.add_view(ModalModelView(Point, db.session, category='Points'))
+admin.add_view(ModalModelView(MultiPoint, db.session, category='Points'))
+admin.add_view(ModalModelView(Polygon, db.session, category='Polygons'))
+admin.add_view(ModalModelView(MultiPolygon, db.session, category='Polygons'))
+admin.add_view(ModalModelView(LineString, db.session, category='Lines'))
+admin.add_view(ModalModelView(MultiLineString, db.session, category='Lines'))
 
 if __name__ == '__main__':
 

--- a/flask_admin/static/admin/js/bs2_modal.js
+++ b/flask_admin/static/admin/js/bs2_modal.js
@@ -2,8 +2,3 @@
 $('.modal').on('hidden', function() {
   $(this).removeData('modal');
 });
-
-$(function() {
-  // Apply flask-admin form styles after the modal is loaded
-  window.faForm.applyGlobalStyles(document);
-});

--- a/flask_admin/static/admin/js/bs3_modal.js
+++ b/flask_admin/static/admin/js/bs3_modal.js
@@ -2,8 +2,3 @@
 $('body').on('hidden.bs.modal', '.modal', function () {
   $(this).removeData('bs.modal').find(".modal-content").empty();
 });
-
-$(function() {
-  // Apply flask-admin form styles after the modal is loaded
-  window.faForm.applyGlobalStyles(document);
-});

--- a/flask_admin/static/admin/js/bs4_modal.js
+++ b/flask_admin/static/admin/js/bs4_modal.js
@@ -2,8 +2,3 @@
 $('body').on('click.modal.data-api', '[data-toggle="modal"]', function () {
     $($(this).data("target") + ' .modal-content').load($(this).attr('href'));
 });
-
-$(function() {
-  // Apply flask-admin form styles after the modal is loaded
-  window.faForm.applyGlobalStyles(document);
-});

--- a/flask_admin/templates/bootstrap2/admin/file/list.html
+++ b/flask_admin/templates/bootstrap2/admin/file/list.html
@@ -193,4 +193,5 @@
     {{ actionslib.script(_gettext('Please select at least one file.'),
                          actions,
                          actions_confirmation) }}
+    <script src="{{ admin_static.url(filename='admin/js/bs2_modal.js', v='1.0.0') }}"></script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap2/admin/model/list.html
+++ b/flask_admin/templates/bootstrap2/admin/model/list.html
@@ -189,6 +189,7 @@
 
     {{ lib.form_js() }}
     <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
+    <script src="{{ admin_static.url(filename='admin/js/bs2_modal.js', v='1.0.0') }}"></script>
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,

--- a/flask_admin/templates/bootstrap2/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/create.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block tail %}
-  <script src="{{ admin_static.url(filename='admin/js/bs2_modal.js', v='1.0.0') }}"></script>
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal'))</script>
 
   <script>
   // fill the header of modal dynamically

--- a/flask_admin/templates/bootstrap2/admin/model/modals/details.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/details.html
@@ -29,7 +29,7 @@
 
 {% block tail %}
   <script src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
-  <script src="{{ admin_static.url(filename='admin/js/bs2_modal.js', v='1.0.0') }}"></script>
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal'))</script>
 
   <script>
   // fill the header of modal dynamically

--- a/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap2/admin/model/modals/edit.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block tail %}
-  <script src="{{ admin_static.url(filename='admin/js/bs2_modal.js', v='1.0.0') }}"></script>
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal'))</script>
 
   <script>
   // fill the header of modal dynamically

--- a/flask_admin/templates/bootstrap3/admin/file/list.html
+++ b/flask_admin/templates/bootstrap3/admin/file/list.html
@@ -193,4 +193,5 @@
     {{ actionslib.script(_gettext('Please select at least one file.'),
                          actions,
                          actions_confirmation) }}
+    <script src="{{ admin_static.url(filename='admin/js/bs3_modal.js', v='1.0.0') }}"></script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/list.html
+++ b/flask_admin/templates/bootstrap3/admin/model/list.html
@@ -190,6 +190,7 @@
 
     {{ lib.form_js() }}
     <script src="{{ admin_static.url(filename='admin/js/filters.js', v='1.0.0') }}"></script>
+    <script src="{{ admin_static.url(filename='admin/js/bs3_modal.js', v='1.0.0') }}"></script>
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,

--- a/flask_admin/templates/bootstrap3/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/create.html
@@ -20,5 +20,5 @@
 {% endblock %}
 
 {% block tail %}
-  <script src="{{ admin_static.url(filename='admin/js/bs3_modal.js', v='1.0.0') }}"></script>
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal-content'));</script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/modals/details.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/details.html
@@ -36,5 +36,5 @@
 
 {% block tail %}
   <script src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
-  <script src="{{ admin_static.url(filename='admin/js/bs3_modal.js', v='1.0.0') }}"></script>
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal-content'));</script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap3/admin/model/modals/edit.html
@@ -22,5 +22,5 @@
 {% endblock %}
 
 {% block tail %}
-  <script src="{{ admin_static.url(filename='admin/js/bs3_modal.js', v='1.0.0') }}"></script>
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal-content'));</script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/create.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/create.html
@@ -30,3 +30,7 @@
 
 
 {% endblock %}
+
+{% block tail %}
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal-content'));</script>
+{% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/details.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/details.html
@@ -36,4 +36,5 @@
 
 {% block tail %}
   <script src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal-content'));</script>
 {% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/model/modals/edit.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/edit.html
@@ -23,5 +23,8 @@
         {{ lib.render_form_buttons(return_url, extra=None, is_modal=True) }}
   </div>
   {% endcall %}
+{% endblock %}
 
+{% block tail %}
+  <script>window.faForm.applyGlobalStyles(document.getElementsByClassName('modal-content'));</script>
 {% endblock %}


### PR DESCRIPTION
In https://github.com/pallets-eco/flask-admin/pull/2407 we removed some seemingly-duplicate network requests for
`bs4_modal.js` every time a modal window is loaded.

This would have been fine if that file did not include any
side-effects, but it did: it re-applied 'global styling' every time the
JS file is loaded.

The goal here was to process 'styling' for any dynamic/interactive
elements, such as map widgets, and fields that use 'select2' or
'x-editable'.

When we removed these 'extra' JS calls, the modal windows stopped
getting these interactive elements enabled/setup.

This patch restores that functionality, while still retaining the goal
of PR https://github.com/pallets-eco/flask-admin/pull/2407: to prevent duplicate network requests for a file.

We load `bs<x>_modal.js` on all pages that can display modals; this file
now only sets up the event listener that is responsible for making sure
a modal is cleared out/refreshed between multiple modal displays.

The logic for applying styling to the window is now added inline to all
of the relevant modal components.

A further improvement on what we had before is that now, the call to add
styling is scoped specifically to the modal. This prevents the issue
described in https://github.com/pallets-eco/flask-admin/issues/2351, where map elements may show up multiple times on
the page because `applyGlobalStyles` is called multiple times.

fixes: #2351 

---

## Current master branch - modals are broken
![2024-07-21 20 44 40](https://github.com/user-attachments/assets/ec63c361-9b26-458a-a345-75f0ae728480)

## Current master branch with #2407 reverted - multiple elements; gets worse over time
![2024-07-21 20 45 56](https://github.com/user-attachments/assets/a0b5c775-e8fd-435b-8c42-5bee0f8db6f4)

## After this PR
![2024-07-21 20 46 47](https://github.com/user-attachments/assets/a998dcca-a89e-4d62-8960-908f477042fb)

---

## To test manually:

* Run `python examples/geo_alchemy/app.py`
* Add some points using the create menu. Maps may be blank unless you've setup mapbox, but you can still save points.
* Go to the list view and load/leave the edit modal a few times.
* The edit modal should show the map widget, and the list view should only show one map instance throughout.

Repeat this on the `master` branch and you'll see the modal view is broken.

Do `git revert 2fbdabce4c19db0eb144b0aa5049eb0ae7c4db37` and `git revert 7df333629faa6baa56d409c507a37882a22c40e9` to manually unwind PR #2407. You'll see the modal view works, but the list view shows more and more elements because global styling is reapplied at the global scope multiple times.