### PR TITLE
Fix translating after WTForms 3 removed form._get_translations

### DIFF
--- a/flask_admin/form/__init__.py
+++ b/flask_admin/form/__init__.py
@@ -14,15 +14,16 @@ from .upload import *  # noqa: F403,F401
 
 
 class BaseForm(form.Form):
-    _translations = Translations()
+    class Meta:
+        _translations = Translations()
+
+        def get_translations(self, form):
+            return self._translations
 
     def __init__(self, formdata=None, obj=None, prefix=u'', **kwargs):
         self._obj = obj
 
         super(BaseForm, self).__init__(formdata=formdata, obj=obj, prefix=prefix, **kwargs)
-
-    def _get_translations(self):
-        return self._translations
 
 
 class FormOpts(object):

--- a/flask_admin/tests/sqla/test_inlineform.py
+++ b/flask_admin/tests/sqla/test_inlineform.py
@@ -272,8 +272,9 @@ def test_inline_form_base_class(app, db, admin):
                 return 'success!'
 
         class StubBaseForm(form.BaseForm):
-            def _get_translations(self):
-                return StubTranslation()
+            class Meta:
+                def get_translations(self, form):
+                    return StubTranslation()
 
         # Set up Admin
         class UserModelView(ModelView):


### PR DESCRIPTION
From #2467 

Meta.get_translations is available in WTForms 2
https://wtforms.readthedocs.io/en/3.1.x/changes/#version-2-0

Upstream docs:
https://wtforms.readthedocs.io/en/3.1.x/i18n/#writing-your-own-translations-provider

I see they instantiate a new MyTranslations every time Meta.get_translations() is called though???
