### PR TITLE
Allow customising `page_size` options, and prevent arbitrary page sizes

### DIFF
--- a/examples/sqla/admin/main.py
+++ b/examples/sqla/admin/main.py
@@ -61,6 +61,7 @@ def is_numberic_validator(form, field):
 
 class UserAdmin(sqla.ModelView):
 
+    can_set_page_size = True
     can_view_details = True  # show a modal dialog with records details
     action_disallowed_list = ['delete', ]
 

--- a/examples/sqla/admin/main.py
+++ b/examples/sqla/admin/main.py
@@ -62,6 +62,8 @@ def is_numberic_validator(form, field):
 class UserAdmin(sqla.ModelView):
 
     can_set_page_size = True
+    page_size = 5
+    page_size_options = (5,10,15)
     can_view_details = True  # show a modal dialog with records details
     action_disallowed_list = ['delete', ]
 

--- a/flask_admin/contrib/appengine/view.py
+++ b/flask_admin/contrib/appengine/view.py
@@ -86,7 +86,7 @@ class NdbModelView(BaseModelView):
                 order_field = -order_field
             q = q.order(order_field)
 
-        if not page_size:
+        if page_size is None:
             page_size = self.page_size
 
         results = q.fetch(page_size, offset=page * page_size)

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -1507,6 +1507,14 @@ class BaseModelView(BaseView, ActionsMixin):
 
         return None
 
+    def get_safe_page_size(self, page_size):
+        safe_page_size = self.page_size
+
+        if self.can_set_page_size and page_size in {20, 50, 100}:
+            safe_page_size = page_size
+
+        return safe_page_size
+
     # Database-related API
     def get_list(self, page, sort_field, sort_desc, search, filters,
                  page_size=None):
@@ -1806,8 +1814,7 @@ class BaseModelView(BaseView, ActionsMixin):
         kwargs = dict(page=page, sort=view_args.sort, desc=desc, search=view_args.search)
         kwargs.update(view_args.extra_args)
 
-        if view_args.page_size:
-            kwargs['page_size'] = view_args.page_size
+        kwargs['page_size'] = self.get_safe_page_size(view_args.page_size)
 
         kwargs.update(self._get_filters(view_args.filters))
 
@@ -1989,7 +1996,7 @@ class BaseModelView(BaseView, ActionsMixin):
             sort_column = sort_column[0]
 
         # Get page size
-        page_size = view_args.page_size or self.page_size
+        page_size = self.get_safe_page_size(view_args.page_size)
 
         # Get count and data
         count, data = self.get_list(view_args.page, sort_column, view_args.sort_desc,

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -788,6 +788,11 @@ class BaseModelView(BaseView, ActionsMixin):
         Allows to select page size via dropdown list
     """
 
+    page_size_options: tuple = (20, 50, 100)
+    """
+        Sets the page size options available, if `can_set_page_size` is True
+    """
+
     def __init__(self, model,
                  name=None, category=None, endpoint=None, url=None, static_folder=None,
                  menu_class_name=None, menu_icon_type=None, menu_icon_value=None):
@@ -832,6 +837,12 @@ class BaseModelView(BaseView, ActionsMixin):
 
         # Scaffolding
         self._refresh_cache()
+
+        if self.can_set_page_size and self.page_size not in self.page_size_options:
+            warnings.warn(
+                f"{self.page_size=} is not in {self.page_size_options=}",
+                UserWarning
+            )
 
     # Endpoint
     def _get_endpoint(self, endpoint):
@@ -1510,7 +1521,7 @@ class BaseModelView(BaseView, ActionsMixin):
     def get_safe_page_size(self, page_size):
         safe_page_size = self.page_size
 
-        if self.can_set_page_size and page_size in {20, 50, 100}:
+        if self.can_set_page_size and page_size in self.page_size_options:
             safe_page_size = page_size
 
         return safe_page_size

--- a/flask_admin/templates/bootstrap4/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap4/admin/model/layout.html
@@ -97,13 +97,13 @@
     </form>
 {% endmacro %}
 
-{% macro page_size_form(generator, btn_class='nav-link dropdown-toggle') %}
+{% macro page_size_form(generator, page_size_options, btn_class='nav-link dropdown-toggle') %}
     <a class="{{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)">
         {{ page_size }} {{ _gettext('items') }}<b class="caret"></b>
     </a>
     <div class="dropdown-menu">
-      <a class="dropdown-item{% if page_size == 20 %} active{% endif %}" href="{{ generator(20) }}">20 {{ _gettext('items') }}</a>
-      <a class="dropdown-item{% if page_size == 50 %} active{% endif %}" href="{{ generator(50) }}">50 {{ _gettext('items') }}</a>
-      <a class="dropdown-item{% if page_size == 100 %} active{% endif %}" href="{{ generator(100) }}">100 {{ _gettext('items') }}</a>
+      {% for option in page_size_options %}
+      <a class="dropdown-item{% if page_size == option %} active{% endif %}" href="{{ generator(option) }}">{{ _ngettext('{} item'.format(option), '{} items'.format(option), option) }}</a>
+      {% endfor %}
     </div>
 {% endmacro %}

--- a/flask_admin/templates/bootstrap4/admin/model/list.html
+++ b/flask_admin/templates/bootstrap4/admin/model/list.html
@@ -41,7 +41,7 @@
 
         {% if can_set_page_size %}
         <li class="nav-item dropdown">
-            {{ model_layout.page_size_form(page_size_url) }}
+            {{ model_layout.page_size_form(page_size_url, admin_view.page_size_options) }}
         </li>
         {% endif %}
 
@@ -190,7 +190,7 @@
     {{ lib.form_js() }}
     <script src="{{ admin_static.url(filename='admin/js/bs4_modal.js', v='1.0.0') }}"></script>
     <script src="{{ admin_static.url(filename='admin/js/bs4_filters.js', v='1.0.0') }}"></script>
-    
+
 
     {{ actionlib.script(_gettext('Please select at least one record.'),
                         actions,

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -1136,6 +1136,58 @@ def test_simple_list_pager(app, db, admin):
     assert count is None
 
 
+def test_customising_page_size(app, db, admin):
+    with app.app_context():
+        M1, _ = create_models(db)
+
+        instances = [M1(test1=f'instance-{x+1:03d}') for x in range(101)]
+        for instance in instances:
+            instance.save()
+
+        view1 = CustomModelView(M1, endpoint='view1', page_size=20, can_set_page_size=False)
+        admin.add_view(view1)
+
+        view2 = CustomModelView(M1, db, endpoint='view2', page_size=5, can_set_page_size=False)
+        admin.add_view(view2)
+
+        view3 = CustomModelView(M1, db, endpoint='view3', page_size=20, can_set_page_size=True)
+        admin.add_view(view3)
+
+        client = app.test_client()
+
+        rv = client.get('/admin/view1/')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+        # `can_set_page_size=False`, so only the default of 20 is available.
+        rv = client.get('/admin/view1/?page_size=50')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+        # Check view2, which has `page_size=5` to change the default page size
+        rv = client.get('/admin/view2/')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        # Check view3, which has `can_set_page_size=True`
+        rv = client.get('/admin/view3/')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+        rv = client.get('/admin/view3/?page_size=50')
+        assert 'instance-050' in rv.text
+        assert 'instance-051' not in rv.text
+
+        rv = client.get('/admin/view3/?page_size=100')
+        assert 'instance-100' in rv.text
+        assert 'instance-101' not in rv.text
+
+        # Invalid page sizes are reset to the default
+        rv = client.get('/admin/view3/?page_size=1')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+
 def test_export_csv(app, db, admin):
     Model1, Model2 = create_models(db)
 

--- a/flask_admin/tests/mongoengine/test_basic.py
+++ b/flask_admin/tests/mongoengine/test_basic.py
@@ -1153,6 +1153,9 @@ def test_customising_page_size(app, db, admin):
         view3 = CustomModelView(M1, db, endpoint='view3', page_size=20, can_set_page_size=True)
         admin.add_view(view3)
 
+        view4 = CustomModelView(M1, db, endpoint='view4', page_size=5, page_size_options=(5,  10, 15), can_set_page_size=True)
+        admin.add_view(view4)
+
         client = app.test_client()
 
         rv = client.get('/admin/view1/')
@@ -1186,6 +1189,24 @@ def test_customising_page_size(app, db, admin):
         rv = client.get('/admin/view3/?page_size=1')
         assert 'instance-020' in rv.text
         assert 'instance-021' not in rv.text
+
+        # Check view4, which has custom `page_size_options`
+        rv = client.get('/admin/view4/')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        # Invalid page sizes are reset to the default
+        rv = client.get('/admin/view4/?page_size=1')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        rv = client.get('/admin/view4/?page_size=10')
+        assert 'instance-010' in rv.text
+        assert 'instance-011' not in rv.text
+
+        rv = client.get('/admin/view4/?page_size=15')
+        assert 'instance-015' in rv.text
+        assert 'instance-016' not in rv.text
 
 
 def test_export_csv(app, db, admin):

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -1037,6 +1037,9 @@ def test_customising_page_size(app, db, admin):
         view3 = CustomModelView(M1, db, endpoint='view3', page_size=20, can_set_page_size=True)
         admin.add_view(view3)
 
+        view4 = CustomModelView(M1, db, endpoint='view4', page_size=5, page_size_options=(5, 10, 15), can_set_page_size=True)
+        admin.add_view(view4)
+
         client = app.test_client()
 
         rv = client.get('/admin/view1/')
@@ -1070,6 +1073,24 @@ def test_customising_page_size(app, db, admin):
         rv = client.get('/admin/view3/?page_size=1')
         assert 'instance-020' in rv.text
         assert 'instance-021' not in rv.text
+
+        # Check view4, which has custom `page_size_options`
+        rv = client.get('/admin/view4/')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        # Invalid page sizes are reset to the default
+        rv = client.get('/admin/view4/?page_size=1')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        rv = client.get('/admin/view4/?page_size=10')
+        assert 'instance-010' in rv.text
+        assert 'instance-011' not in rv.text
+
+        rv = client.get('/admin/view4/?page_size=15')
+        assert 'instance-015' in rv.text
+        assert 'instance-016' not in rv.text
 
 
 def test_export_csv(app, db, admin):

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -2456,6 +2456,9 @@ def test_customising_page_size(app, db, admin):
         view3 = CustomModelView(M1, db.session, endpoint='view3', page_size=20, can_set_page_size=True)
         admin.add_view(view3)
 
+        view4 = CustomModelView(M1, db.session, endpoint='view4', page_size=5, page_size_options=(5, 10, 15), can_set_page_size=True)
+        admin.add_view(view4)
+
         client = app.test_client()
 
         rv = client.get('/admin/view1/')
@@ -2489,6 +2492,24 @@ def test_customising_page_size(app, db, admin):
         rv = client.get('/admin/view3/?page_size=1')
         assert 'instance-020' in rv.text
         assert 'instance-021' not in rv.text
+
+        # Check view4, which has custom `page_size_options`
+        rv = client.get('/admin/view4/')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        # Invalid page sizes are reset to the default
+        rv = client.get('/admin/view4/?page_size=1')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        rv = client.get('/admin/view4/?page_size=10')
+        assert 'instance-010' in rv.text
+        assert 'instance-011' not in rv.text
+
+        rv = client.get('/admin/view4/?page_size=15')
+        assert 'instance-015' in rv.text
+        assert 'instance-016' not in rv.text
 
 
 def test_unlimited_page_size(app, db, admin):

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -2439,6 +2439,58 @@ def test_simple_list_pager(app, db, admin):
         assert count is None
 
 
+def test_customising_page_size(app, db, admin):
+    with app.app_context():
+        M1, _ = create_models(db)
+
+        db.session.add_all(
+            [M1(str(f'instance-{x+1:03d}')) for x in range(101)]
+        )
+
+        view1 = CustomModelView(M1, db.session, endpoint='view1', page_size=20, can_set_page_size=False)
+        admin.add_view(view1)
+
+        view2 = CustomModelView(M1, db.session, endpoint='view2', page_size=5, can_set_page_size=False)
+        admin.add_view(view2)
+
+        view3 = CustomModelView(M1, db.session, endpoint='view3', page_size=20, can_set_page_size=True)
+        admin.add_view(view3)
+
+        client = app.test_client()
+
+        rv = client.get('/admin/view1/')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+        # `can_set_page_size=False`, so only the default of 20 is available.
+        rv = client.get('/admin/view1/?page_size=50')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+        # Check view2, which has `page_size=5` to change the default page size
+        rv = client.get('/admin/view2/')
+        assert 'instance-005' in rv.text
+        assert 'instance-006' not in rv.text
+
+        # Check view3, which has `can_set_page_size=True`
+        rv = client.get('/admin/view3/')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+        rv = client.get('/admin/view3/?page_size=50')
+        assert 'instance-050' in rv.text
+        assert 'instance-051' not in rv.text
+
+        rv = client.get('/admin/view3/?page_size=100')
+        assert 'instance-100' in rv.text
+        assert 'instance-101' not in rv.text
+
+        # Invalid page sizes are reset to the default
+        rv = client.get('/admin/view3/?page_size=1')
+        assert 'instance-020' in rv.text
+        assert 'instance-021' not in rv.text
+
+
 def test_unlimited_page_size(app, db, admin):
     with app.app_context():
         M1, _ = create_models(db)


### PR DESCRIPTION
Makes two changes:

- Prevents users from entering arbitrary values for `page_size` in the URL when `can_set_page_size` is True
- Allows customising the `page_size` options available to users. The default is `(20, 50, 100)`.

---

fixes: https://github.com/pallets-eco/flask-admin/issues/2430
fixes: https://github.com/pallets-eco/flask-admin/issues/2412