### PR TITLE
Fix test_different_bind_joins UnboundExecutionError

### DIFF
--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -2637,12 +2637,11 @@ def test_multipath_joins(app, db, admin):
         assert rv.status_code == 200
 
 
-# TODO: Why this fails?
-@pytest.mark.xfail(raises=Exception)
-def test_different_bind_joins(app, db, admin):
-    app.config['SQLALCHEMY_BINDS'] = {
-        'other': 'sqlite:///'
-    }
+def test_different_bind_joins(request, app):
+    app.config['SQLALCHEMY_BINDS'] = {'other': 'sqlite:///'}
+
+    db = request.getfixturevalue('db')
+    admin = request.getfixturevalue('admin')
 
     with app.app_context():
         class Model1(db.Model):


### PR DESCRIPTION
sqlalchemy.exc.UnboundExecutionError: Bind key 'other' is not in 'SQLALCHEMY_BINDS' config.

---

An update of a commit from #2328.

I'm no fixtures expert so maybe there is a better way, although this does seem to be a one-off at this time.
