### PR TITLE
Revert "Add SQLAlchemy 1 support back to test_multi_pk.py"

### DIFF
--- a/flask_admin/tests/sqla/test_multi_pk.py
+++ b/flask_admin/tests/sqla/test_multi_pk.py
@@ -1,11 +1,7 @@
 from .test_basic import CustomModelView
 
 from flask_sqlalchemy.model import Model
-try:
-    # SQLAlchemy 2.0
-    from sqlalchemy.orm import declarative_base
-except ImportError:
-    from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 
 def test_multiple_pk(app, db, admin):


### PR DESCRIPTION
declarative_base is available from sqlalchemy.orm in SQLAlchemy 1.4.

This reverts commit a050b567035c605bd44dd837108c0e24cbfd4c12.

---

That final commit in #2483 wasn't needed.