### PR TITLE
Replace obsolete intersphinx_mapping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,7 +251,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # fall back if theme is not there
 try:


### PR DESCRIPTION
Old format removed in Sphinx 8.0, new format introduced in Sphinx 1.0.
