### PR TITLE
Replace filter support for sqlalchemy_enum34 with sqlalchemy.Enum

### DIFF
--- a/flask_admin/contrib/sqla/filters.py
+++ b/flask_admin/contrib/sqla/filters.py
@@ -288,54 +288,54 @@ class TimeNotBetweenFilter(TimeBetweenFilter):
 
 
 class EnumEqualFilter(FilterEqual):
-    def __init__(self, column, name, options=None, enum_class=None, **kwargs):
-        self.enum_class = enum_class
+    def __init__(self, column, name, options=None, **kwargs):
+        self.enum_class = column.type.enum_class
         super(EnumEqualFilter, self).__init__(column, name, options, **kwargs)
 
     def clean(self, value):
         if self.enum_class is None:
             return super(EnumEqualFilter, self).clean(value)
-        return self.enum_class(value)
+        return self.enum_class[value]
 
 
 class EnumFilterNotEqual(FilterNotEqual):
-    def __init__(self, column, name, options=None, enum_class=None, **kwargs):
-        self.enum_class = enum_class
+    def __init__(self, column, name, options=None, **kwargs):
+        self.enum_class = column.type.enum_class
         super(EnumFilterNotEqual, self).__init__(column, name, options, **kwargs)
 
     def clean(self, value):
         if self.enum_class is None:
             return super(EnumFilterNotEqual, self).clean(value)
-        return self.enum_class(value)
+        return self.enum_class[value]
 
 
 class EnumFilterEmpty(FilterEmpty):
-    def __init__(self, column, name, options=None, enum_class=None, **kwargs):
-        self.enum_class = enum_class
+    def __init__(self, column, name, options=None, **kwargs):
+        self.enum_class = column.type.enum_class
         super(EnumFilterEmpty, self).__init__(column, name, options, **kwargs)
 
 
 class EnumFilterInList(FilterInList):
-    def __init__(self, column, name, options=None, enum_class=None, **kwargs):
-        self.enum_class = enum_class
+    def __init__(self, column, name, options=None, **kwargs):
+        self.enum_class = column.type.enum_class
         super(EnumFilterInList, self).__init__(column, name, options, **kwargs)
 
     def clean(self, value):
         values = super(EnumFilterInList, self).clean(value)
         if self.enum_class is not None:
-            values = [self.enum_class(val) for val in values]
+            values = [self.enum_class[val] for val in values]
         return values
 
 
 class EnumFilterNotInList(FilterNotInList):
-    def __init__(self, column, name, options=None, enum_class=None, **kwargs):
-        self.enum_class = enum_class
+    def __init__(self, column, name, options=None, **kwargs):
+        self.enum_class = column.type.enum_class
         super(EnumFilterNotInList, self).__init__(column, name, options, **kwargs)
 
     def clean(self, value):
         values = super(EnumFilterNotInList, self).clean(value)
         if self.enum_class is not None:
-            values = [self.enum_class(val) for val in values]
+            values = [self.enum_class[val] for val in values]
         return values
 
 
@@ -540,13 +540,6 @@ class FilterConverter(filters.BaseFilterConverter):
                 (v, v)
                 for v in column.type.enums
             ]
-        try:
-            from sqlalchemy_enum34 import EnumType
-        except ImportError:
-            pass
-        else:
-            if isinstance(column.type, EnumType):
-                kwargs['enum_class'] = column.type._enum_class
 
         return [f(column, name, options, **kwargs) for f in self.enum]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,6 @@ module = [
     "playhouse.*",
     "pymongo",
     "sqlalchemy.*",
-    "sqlalchemy_enum34",
     "sqlalchemy_utils",
     "tablib",
     "wtforms.*",


### PR DESCRIPTION
PEP-435-style enumerated classes supported by sqlalchemy.Enum since SQLAlchemy 1.1.

---

We have no tests using sqlalchemy_enum34. The last SQLAlchemy-Enum34 release was in 2021.

sqlalchemy_enum34 is no longer necessary in applications and appears to be straightforward to replace.
