### PR TITLE
Update PostGIS Docker image

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgis/postgis:12-master # postgres with postgis installed
+        image: postgis/postgis:16-3.4  # postgres with postgis installed
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
12-master was last updated 3 years ago.
PostgreSQL 12 will stop receiving fixes in November 2024.
