### PR TITLE
Add jinja2, markupsafe and werkzeug to dependencies

### DIFF
--- a/flask_admin/_backwards.py
+++ b/flask_admin/_backwards.py
@@ -8,12 +8,6 @@
 import sys
 import warnings
 
-try:
-    from wtforms.widgets import HTMLString as Markup  # type: ignore[attr-defined]
-except ImportError:
-    # WTForms 2.3.0
-    from markupsafe import Markup  # noqa: F401
-
 
 def get_property(obj, name, old_name, default=None):
     """

--- a/flask_admin/_compat.py
+++ b/flask_admin/_compat.py
@@ -37,10 +37,3 @@ def as_unicode(s):
 def csv_encode(s):
     ''' Returns unicode string expected by Python 3's csv module '''
     return as_unicode(s)
-
-
-try:
-    # jinja2 3.0.0
-    from jinja2 import pass_context  # type: ignore[attr-defined]
-except ImportError:
-    from jinja2 import contextfunction as pass_context

--- a/flask_admin/contrib/sqla/widgets.py
+++ b/flask_admin/contrib/sqla/widgets.py
@@ -1,6 +1,5 @@
+from markupsafe import Markup
 from wtforms.widgets.core import escape  # type: ignore[attr-defined]
-
-from flask_admin._backwards import Markup
 
 
 class CheckboxListInput:

--- a/flask_admin/form/upload.py
+++ b/flask_admin/form/upload.py
@@ -4,6 +4,8 @@ from types import ModuleType
 from typing import Optional
 from urllib.parse import urljoin
 
+from markupsafe import Markup
+
 from werkzeug.utils import secure_filename
 from werkzeug.datastructures import FileStorage
 
@@ -14,7 +16,6 @@ from wtforms.widgets import html_params
 from flask_admin.babel import gettext
 from flask_admin.helpers import get_url
 
-from flask_admin._backwards import Markup
 from flask_admin._compat import string_types
 
 Image: Optional[ModuleType]

--- a/flask_admin/helpers.py
+++ b/flask_admin/helpers.py
@@ -3,10 +3,11 @@ from typing import Callable, Optional
 from urllib.parse import urljoin, urlparse
 
 from flask import g, request, url_for, flash
+from jinja2 import pass_context  # type: ignore[attr-defined]
 from markupsafe import Markup
 from wtforms.validators import DataRequired, InputRequired
 
-from flask_admin._compat import iteritems, pass_context
+from flask_admin._compat import iteritems
 
 from ._compat import string_types
 

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -9,6 +9,7 @@ from math import ceil
 import inspect
 from collections import OrderedDict
 
+from jinja2 import pass_context  # type: ignore[attr-defined]
 from werkzeug.utils import secure_filename
 
 from flask import (current_app, request, redirect, flash, abort, json,
@@ -36,7 +37,7 @@ from flask_admin.helpers import (get_form_data, validate_form_on_submit,
 from flask_admin.tools import rec_getattr
 from flask_admin._backwards import ObsoleteAttr
 from flask_admin._compat import (iteritems, itervalues,
-                                 as_unicode, csv_encode, text_type, pass_context)
+                                 as_unicode, csv_encode, text_type)
 from .helpers import prettify_name, get_mdict_item_or_list
 from .ajax import AjaxModelLoader
 

--- a/flask_admin/model/template.py
+++ b/flask_admin/model/template.py
@@ -1,6 +1,8 @@
 from functools import reduce
 
-from flask_admin._compat import pass_context, string_types
+from jinja2 import pass_context  # type: ignore[attr-defined]
+
+from flask_admin._compat import string_types
 from flask_admin.babel import gettext
 
 

--- a/flask_admin/model/widgets.py
+++ b/flask_admin/model/widgets.py
@@ -1,8 +1,7 @@
 from flask import json
-from markupsafe import escape
+from markupsafe import escape, Markup
 from wtforms.widgets import html_params
 
-from flask_admin._backwards import Markup
 from flask_admin._compat import as_unicode, text_type
 from flask_admin.babel import gettext
 from flask_admin.helpers import get_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ requires-python = ">=3.8"
 dependencies = [
     "flask>=2.0",
     "jinja2>=3.0",
-    "wtforms>=2",
+    "markupsafe>=2.0",
+    "wtforms>=2.3",
 ]
 
 [project.optional-dependencies]
@@ -92,7 +93,6 @@ filterwarnings = [
     "error",
     # TODO: remove the ignored deprecation warning when support for WTForms 3 has been added.
     "ignore:Flags should be stored in dicts and not in tuples. The next version of WTForms will abandon support for flags in tuples.:DeprecationWarning",
-    "ignore:'HTMLString' will be removed in WTForms 3.0. Use 'markupsafe.Markup' instead.:DeprecationWarning",
 
     # Werkzeug is responsible for the below deprecation warning; remove when they have updated their code.
     "default:ast\\.Str is deprecated and will be removed in Python 3\\.14:DeprecationWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "flask>=2.0",
     "jinja2>=3.0",
     "markupsafe>=2.0",
+    "werkzeug>=2.0",
     "wtforms>=2.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "flask>=2.0",
+    "jinja2>=3.0",
     "wtforms>=2",
 ]
 


### PR DESCRIPTION
**Draft because the pyproject.toml changes will clash with other open PRs**, will need a rebase, maybe some adjustment of the versions.

These are all direct mandatory dependencies.

Specifying them (plus wtforms>=2.3 - released 2020) allows some further clean-up of _backwards.py and _compat.py and a filtered warning to be removed.
