### PR TITLE
Fix styling when CSP is enabled

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/actions.html
+++ b/flask_admin/templates/bootstrap4/admin/actions.html
@@ -13,7 +13,7 @@
 
 {% macro form(actions, url) %}
     {% if actions %}
-        <form id="action_form" action="{{ url }}" method="POST" style="display: none">
+        <form id="action_form" action="{{ url }}" method="POST" class="d-none">
             {% if action_form.csrf_token %}
                 {{ action_form.csrf_token }}
             {% elif csrf_token %}
@@ -27,8 +27,8 @@
 
 {% macro script(message, actions, actions_confirmation) %}
     {% if actions %}
-        <div id="actions-confirmation-data" style="display:none;">{{ actions_confirmation|tojson|safe }}</div>
-        <div id="message-data" style="display:none;">{{ message|tojson|safe }}</div>
+        <div id="actions-confirmation-data" class="d-none">{{ actions_confirmation|tojson|safe }}</div>
+        <div id="message-data" class="d-none">{{ message|tojson|safe }}</div>
         <script {{ admin_csp_nonce_attribute }} src="{{ admin_static.url(filename='admin/js/actions.js', v='1.0.0') }}"></script>
     {% endif %}
 {% endmacro %}

--- a/flask_admin/templates/bootstrap4/admin/base.html
+++ b/flask_admin/templates/bootstrap4/admin/base.html
@@ -24,11 +24,6 @@
             <link href="{{ css_url }}" rel="stylesheet" {{ admin_csp_nonce_attribute }}>
           {% endfor %}
         {% endif %}
-        <style {{ admin_csp_nonce_attribute }}>
-            .hide {
-                display: none;
-            }
-        </style>
     {% endblock %}
     {% block head %}
     {% endblock %}

--- a/flask_admin/templates/bootstrap4/admin/lib.html
+++ b/flask_admin/templates/bootstrap4/admin/lib.html
@@ -120,9 +120,9 @@
   {% set prepend = kwargs.pop('prepend', None) %}
   {% set append = kwargs.pop('append', None) %}
   <div class="form-group {{ kwargs.get('column_class', '') }}">
-    <label for="{{ field.id }}" class="control-label" {% if field.widget.input_type == 'checkbox' %}style="display: block; margin-bottom: 0"{% endif %}>{{ field.label.text }}
+    <label for="{{ field.id }}" class="control-label {% if field.widget.input_type == 'checkbox' %}d-block mb-0{% endif %}">{{ field.label.text }}
         {% if h.is_required_form_field(field) %}
-          <strong style="color: red">&#42;</strong>
+          <strong class="text-danger"">&#42;</strong>
         {%- else -%}
           &nbsp;
         {%- endif %}
@@ -151,14 +151,14 @@
       {%- endif -%}
       {% if direct_error %}
         <div class="invalid-feedback">
-          <ul class="form-text text-muted" {% if field.widget.input_type == 'checkbox' %}style="margin-top: 0"{% endif %}>
+          <ul class="form-text text-muted {% if field.widget.input_type == 'checkbox' %}mt-0{% endif %}">
           {% for e in field.errors if e is string %}
             <li>{{ e }}</li>
           {% endfor %}
           </ul>
         </div>
       {% elif field.description %}
-        <small class="form-text text-muted" {% if field.widget.input_type == 'checkbox' %}style="margin-top: 0"{% endif %}>
+        <small class="form-text text-muted {% if field.widget.input_type == 'checkbox' %}mt-0{% endif %}">
             {{ field.description|safe }}
         </small>
       {% endif %}

--- a/flask_admin/templates/bootstrap4/admin/model/inline_list_base.html
+++ b/flask_admin/templates/bootstrap4/admin/model/inline_list_base.html
@@ -11,7 +11,7 @@
                     <div class="pull-right">
                         {% if subfield.get_pk and subfield.get_pk() %}
                         <input type="checkbox" name="del-{{ subfield.id }}" id="del-{{ subfield.id }}" />
-                        <label for="del-{{ subfield.id }}" style="display: inline">{{ _gettext('Delete?') }}</label>
+                        <label for="del-{{ subfield.id }}" class="d-inline">{{ _gettext('Delete?') }}</label>
                         {% else %}
                         <a href="javascript:void(0)" value="{{ _gettext('Are you sure you want to delete this record?') }}" class="inline-remove-field"><i class="fa fa-times glyphicon glyphicon-remove"></i></a>
                         {% endif %}
@@ -26,7 +26,7 @@
     </div>
 
     {# template for new inline form fields #}
-    <div class="inline-field-template hide">
+    <div class="inline-field-template d-none">
         {% filter forceescape %}
         <div class="inline-field card card-body bg-light mb-3">
             <legend>

--- a/flask_admin/templates/bootstrap4/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap4/admin/model/layout.html
@@ -46,7 +46,7 @@
             <input type="hidden" name="page_size" value="{{ page_size }}">
         {% endif %}
         <div class="pull-right">
-            <button type="submit" class="btn btn-primary" style="display: none">{{ _gettext('Apply') }}</button>
+            <button type="submit" class="btn btn-primary" class="d-none">{{ _gettext('Apply') }}</button>
             {% if active_filters %}
                 <a href="{{ clear_search_url }}" class="btn btn-secondary">{{ _gettext('Reset Filters') }}</a>
             {% endif %}

--- a/flask_admin/templates/bootstrap4/admin/model/list.html
+++ b/flask_admin/templates/bootstrap4/admin/model/list.html
@@ -184,8 +184,8 @@
     {{ super() }}
 
     {% if filter_groups %}
-      <div id="filter-groups-data" style="display:none;">{{ filter_groups|tojson|safe }}</div>
-      <div id="active-filters-data" style="display:none;">{{ active_filters|tojson|safe }}</div>
+      <div id="filter-groups-data" class="d-none">{{ filter_groups|tojson|safe }}</div>
+      <div id="active-filters-data" class="d-none">{{ active_filters|tojson|safe }}</div>
     {% endif %}
     {{ lib.form_js() }}
     <script {{ admin_csp_nonce_attribute }} src="{{ admin_static.url(filename='admin/js/bs4_modal.js', v='1.0.0') }}"></script>

--- a/flask_admin/templates/bootstrap4/admin/rediscli/console.html
+++ b/flask_admin/templates/bootstrap4/admin/rediscli/console.html
@@ -22,6 +22,6 @@
 {% block tail %}
   {{ super() }}
 
-  <div id="execute-view-data" style="display:none;">{{ admin_view.get_url('.execute_view')|tojson|safe }}</div>
+  <div id="execute-view-data" class="d-none">{{ admin_view.get_url('.execute_view')|tojson|safe }}</div>
   <script {{ admin_csp_nonce_attribute }} src="{{ admin_static.url(filename='admin/js/rediscli.js', v='1.0.0') }}"></script>
 {% endblock %}

--- a/flask_admin/tests/test_csp.py
+++ b/flask_admin/tests/test_csp.py
@@ -32,6 +32,6 @@ def test_csp_nonces_injected(app, admin, nonce):
         assert tag.attrs['nonce'] == nonce
 
     styles = soup.select('style')
-    assert len(styles) == 1
+    assert len(styles) == 0
     for tag in styles:
         assert tag.attrs['nonce'] == nonce


### PR DESCRIPTION
`style` attributes don't work with CSP, so this removes any style attributes and replaces them with Bootstrap classes that provide the same styles.