### PR TITLE
[pallets-eco#2505] fixing inconsistent modal headers

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/model/modals/details.html
+++ b/flask_admin/templates/bootstrap4/admin/model/modals/details.html
@@ -4,7 +4,7 @@
 {% block body %}
   <div class="modal-header">
     {% block header_text %}
-      <h3>{{ _gettext('View Record') + ' #' + request.args.get('id') }}</h3>
+      <h5 class="modal-title">{{ _gettext('View Record') + ' #' + request.args.get('id') }}</h5>
     {% endblock %}
     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
   </div>


### PR DESCRIPTION
Fixes #2505:
* "View Record" modal header styling is no longer inconsistent with "Edit Record" & "Create New Record"

Before:
![create](https://github.com/user-attachments/assets/f5ae579f-312c-4721-9226-b1e038acc15c)
![edit](https://github.com/user-attachments/assets/ac94386b-a002-4a67-a806-804e20558fa8)
![view-h5](https://github.com/user-attachments/assets/bc78ce06-485b-4069-a7d7-fecb0d0c17b9)
After:
![view-h5](https://github.com/user-attachments/assets/495aa13f-cef1-4bf0-a343-ee1074740ee4)
![edit](https://github.com/user-attachments/assets/ac94386b-a002-4a67-a806-804e20558fa8)
![create](https://github.com/user-attachments/assets/f5ae579f-312c-4721-9226-b1e038acc15c)
