### PR TITLE
Remove unused coveralls requirement

### DIFF
--- a/requirements-skip/tests-min.in
+++ b/requirements-skip/tests-min.in
@@ -1,4 +1,3 @@
-coveralls
 flake8
 pylint
 pytest

--- a/requirements-skip/tests-min.txt
+++ b/requirements-skip/tests-min.txt
@@ -16,13 +16,13 @@ azure-storage-blob==2.1.0
     # via -r tests-min.in
 azure-storage-common==2.1.0
     # via azure-storage-blob
-babel==2.15.0
+babel==2.16.0
     # via flask-babel
 beautifulsoup4==4.12.3
     # via -r tests-min.in
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
@@ -30,13 +30,9 @@ click==8.1.7
     # via flask
 colour==0.1.5
     # via -r tests-min.in
-coverage[toml]==7.6.0
-    # via
-    #   coveralls
-    #   pytest-cov
-coveralls==4.0.1
-    # via -r tests-min.in
-cryptography==43.0.0
+coverage[toml]==7.6.1
+    # via pytest-cov
+cryptography==43.0.1
     # via azure-storage-common
 deprecated==1.2.14
     # via redis
@@ -44,13 +40,11 @@ dill==0.3.8
     # via pylint
 dnspython==2.6.1
     # via email-validator
-docopt==0.6.2
-    # via coveralls
 email-validator==2.0.0
     # via -r tests-min.in
 exceptiongroup==1.2.2
     # via pytest
-flake8==7.1.0
+flake8==7.1.1
     # via -r tests-min.in
 flask==2.2.0
     # via
@@ -65,11 +59,11 @@ geoalchemy2==0.14.0
     # via -r tests-min.in
 greenlet==3.0.3
     # via sqlalchemy
-idna==3.7
+idna==3.8
     # via
     #   email-validator
     #   requests
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via flask
 iniconfig==2.0.0
     # via pytest
@@ -108,13 +102,13 @@ pluggy==1.5.0
     # via pytest
 psycopg2==2.9.9
     # via -r tests-min.in
-pycodestyle==2.12.0
+pycodestyle==2.12.1
     # via flake8
 pycparser==2.22
     # via cffi
 pyflakes==3.2.0
     # via flake8
-pylint==3.2.6
+pylint==3.2.7
     # via -r tests-min.in
 pymongo==3.7.0
     # via -r tests-min.in
@@ -135,16 +129,14 @@ pytz==2022.7.1
 redis==4.0.0
     # via -r tests-min.in
 requests==2.32.3
-    # via
-    #   azure-storage-common
-    #   coveralls
+    # via azure-storage-common
 shapely==2.0.0
     # via -r tests-min.in
 six==1.16.0
     # via
     #   python-dateutil
     #   sqlalchemy-utils
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sqlalchemy==1.4.18
     # via
@@ -164,7 +156,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via
@@ -184,5 +176,5 @@ wtforms==2.3.0
     # via
     #   -r tests-min.in
     #   wtf-peewee
-zipp==3.19.2
+zipp==3.20.1
     # via importlib-metadata

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -6,7 +6,7 @@
 #
 build==1.2.1
     # via -r build.in
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via build
 packaging==24.1
     # via build
@@ -14,5 +14,5 @@ pyproject-hooks==1.1.0
     # via build
 tomli==2.0.1
     # via build
-zipp==3.19.2
+zipp==3.20.1
     # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,20 +13,20 @@ astroid==3.2.4
     #   -r docs.txt
     #   -r typing.txt
     #   pylint
-babel==2.15.0
+babel==2.16.0
     # via
     #   -r docs.txt
     #   sphinx
 beautifulsoup4==4.12.3
     # via
+    #   -r docs.txt
     #   -r tests.in
     #   -r typing.txt
-cachetools==5.4.0
+cachetools==5.5.0
     # via tox
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   -r docs.txt
-    #   -r typing.txt
     #   requests
 cfgv==3.4.0
     # via pre-commit
@@ -35,21 +35,14 @@ chardet==5.2.0
 charset-normalizer==3.3.2
     # via
     #   -r docs.txt
-    #   -r typing.txt
     #   requests
 colorama==0.4.6
     # via tox
-coverage[toml]==7.6.0
+coverage[toml]==7.6.1
     # via
     #   -r docs.txt
     #   -r typing.txt
-    #   coveralls
     #   pytest-cov
-coveralls==4.0.1
-    # via
-    #   -r docs.txt
-    #   -r tests.in
-    #   -r typing.txt
 dill==0.3.8
     # via
     #   -r docs.txt
@@ -57,11 +50,6 @@ dill==0.3.8
     #   pylint
 distlib==0.3.8
     # via virtualenv
-docopt==0.6.2
-    # via
-    #   -r docs.txt
-    #   -r typing.txt
-    #   coveralls
 docutils==0.20.1
     # via
     #   -r docs.txt
@@ -75,23 +63,22 @@ filelock==3.15.4
     # via
     #   tox
     #   virtualenv
-flake8==7.1.0
+flake8==7.1.1
     # via
     #   -r docs.txt
     #   -r tests.in
     #   -r typing.txt
 identify==2.6.0
     # via pre-commit
-idna==3.7
+idna==3.8
     # via
     #   -r docs.txt
-    #   -r typing.txt
     #   requests
 imagesize==1.4.1
     # via
     #   -r docs.txt
     #   sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via
     #   -r docs.txt
     #   sphinx
@@ -167,7 +154,7 @@ psycopg2==2.9.9
     #   -r docs.txt
     #   -r tests.in
     #   -r typing.txt
-pycodestyle==2.12.0
+pycodestyle==2.12.1
     # via
     #   -r docs.txt
     #   -r typing.txt
@@ -181,14 +168,14 @@ pygments==2.18.0
     # via
     #   -r docs.txt
     #   sphinx
-pylint==3.2.6
+pylint==3.2.7
     # via
     #   -r docs.txt
     #   -r tests.in
     #   -r typing.txt
 pyproject-api==1.7.1
     # via tox
-pyright==1.1.378
+pyright==1.1.379
     # via -r typing.txt
 pytest==8.3.2
     # via
@@ -205,20 +192,19 @@ pytz==2024.1
     # via
     #   -r docs.txt
     #   babel
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via pre-commit
 requests==2.32.3
     # via
     #   -r docs.txt
-    #   -r typing.txt
-    #   coveralls
     #   sphinx
 snowballstemmer==2.2.0
     # via
     #   -r docs.txt
     #   sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via
+    #   -r docs.txt
     #   -r typing.txt
     #   beautifulsoup4
 sphinx==7.1.2
@@ -262,7 +248,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r docs.txt
     #   -r typing.txt
@@ -281,7 +267,7 @@ types-flask==1.1.6
     # via -r typing.txt
 types-flask-sqlalchemy==2.5.9.4
     # via -r typing.txt
-types-html5lib==1.1.11.20240228
+types-html5lib==1.1.11.20240806
     # via
     #   -r typing.txt
     #   types-beautifulsoup4
@@ -319,13 +305,12 @@ typing-extensions==4.12.2
 urllib3==2.2.2
     # via
     #   -r docs.txt
-    #   -r typing.txt
     #   requests
 virtualenv==20.26.3
     # via
     #   pre-commit
     #   tox
-zipp==3.19.2
+zipp==3.20.1
     # via
     #   -r docs.txt
     #   importlib-metadata

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,33 +8,29 @@ alabaster==0.7.13
     # via sphinx
 astroid==3.2.4
     # via pylint
-babel==2.15.0
+babel==2.16.0
     # via sphinx
-certifi==2024.7.4
+beautifulsoup4==4.12.3
+    # via -r tests.in
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage[toml]==7.6.0
-    # via
-    #   coveralls
-    #   pytest-cov
-coveralls==4.0.1
-    # via -r tests.in
+coverage[toml]==7.6.1
+    # via pytest-cov
 dill==0.3.8
     # via pylint
-docopt==0.6.2
-    # via coveralls
 docutils==0.20.1
     # via sphinx
 exceptiongroup==1.2.2
     # via pytest
-flake8==7.1.0
+flake8==7.1.1
     # via -r tests.in
-idna==3.7
+idna==3.8
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.2.0
+importlib-metadata==8.4.0
     # via sphinx
 iniconfig==2.0.0
     # via pytest
@@ -61,13 +57,13 @@ pluggy==1.5.0
     # via pytest
 psycopg2==2.9.9
     # via -r tests.in
-pycodestyle==2.12.0
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
 pygments==2.18.0
     # via sphinx
-pylint==3.2.6
+pylint==3.2.7
     # via -r tests.in
 pytest==8.3.2
     # via
@@ -78,11 +74,11 @@ pytest-cov==5.0.0
 pytz==2024.1
     # via babel
 requests==2.32.3
-    # via
-    #   coveralls
-    #   sphinx
+    # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.6
+    # via beautifulsoup4
 sphinx==7.1.2
     # via
     #   -r docs.in
@@ -107,7 +103,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via
@@ -115,5 +111,5 @@ typing-extensions==4.12.2
     #   pylint
 urllib3==2.2.2
     # via requests
-zipp==3.19.2
+zipp==3.20.1
     # via importlib-metadata

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,4 +1,3 @@
-coveralls
 flake8
 pylint
 pytest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,26 +8,14 @@ astroid==3.2.4
     # via pylint
 beautifulsoup4==4.12.3
     # via -r tests.in
-certifi==2024.7.4
-    # via requests
-charset-normalizer==3.3.2
-    # via requests
-coverage[toml]==7.6.0
-    # via
-    #   coveralls
-    #   pytest-cov
-coveralls==4.0.1
-    # via -r tests.in
+coverage[toml]==7.6.1
+    # via pytest-cov
 dill==0.3.8
     # via pylint
-docopt==0.6.2
-    # via coveralls
 exceptiongroup==1.2.2
     # via pytest
-flake8==7.1.0
+flake8==7.1.1
     # via -r tests.in
-idna==3.7
-    # via requests
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
@@ -44,11 +32,11 @@ pluggy==1.5.0
     # via pytest
 psycopg2==2.9.9
     # via -r tests.in
-pycodestyle==2.12.0
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pylint==3.2.6
+pylint==3.2.7
     # via -r tests.in
 pytest==8.3.2
     # via
@@ -56,20 +44,16 @@ pytest==8.3.2
     #   pytest-cov
 pytest-cov==5.0.0
     # via -r tests.in
-requests==2.32.3
-    # via coveralls
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 tomli==2.0.1
     # via
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via
     #   astroid
     #   pylint
-urllib3==2.2.2
-    # via requests

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -8,26 +8,14 @@ astroid==3.2.4
     # via pylint
 beautifulsoup4==4.12.3
     # via -r tests.in
-certifi==2024.7.4
-    # via requests
-charset-normalizer==3.3.2
-    # via requests
-coverage[toml]==7.6.0
-    # via
-    #   coveralls
-    #   pytest-cov
-coveralls==4.0.1
-    # via -r tests.in
+coverage[toml]==7.6.1
+    # via pytest-cov
 dill==0.3.8
     # via pylint
-docopt==0.6.2
-    # via coveralls
 exceptiongroup==1.2.2
     # via pytest
-flake8==7.1.0
+flake8==7.1.1
     # via -r tests.in
-idna==3.7
-    # via requests
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
@@ -54,13 +42,13 @@ pluggy==1.5.0
     # via pytest
 psycopg2==2.9.9
     # via -r tests.in
-pycodestyle==2.12.0
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via flake8
-pylint==3.2.6
+pylint==3.2.7
     # via -r tests.in
-pyright==1.1.378
+pyright==1.1.379
     # via -r typing.in
 pytest==8.3.2
     # via
@@ -69,9 +57,7 @@ pytest==8.3.2
     #   pytest-cov
 pytest-cov==5.0.0
     # via -r tests.in
-requests==2.32.3
-    # via coveralls
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 tomli==2.0.1
     # via
@@ -79,7 +65,7 @@ tomli==2.0.1
     #   mypy
     #   pylint
     #   pytest
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
 types-beautifulsoup4==4.12.0.20240511
     # via -r typing.in
@@ -91,7 +77,7 @@ types-flask==1.1.6
     # via -r typing.in
 types-flask-sqlalchemy==2.5.9.4
     # via -r typing.in
-types-html5lib==1.1.11.20240228
+types-html5lib==1.1.11.20240806
     # via types-beautifulsoup4
 types-jinja2==2.11.9
     # via types-flask
@@ -114,5 +100,3 @@ typing-extensions==4.12.2
     #   astroid
     #   mypy
     #   pylint
-urllib3==2.2.2
-    # via requests


### PR DESCRIPTION
Added in:
bb93ee7c ("Test python 3.5, and use coveralls and pylint.", 2016-03-10)

---

Looks like it was added for use with Travis. If we want to use a similar service on GitHub then there are Actions available.
