### PR TITLE
Filter unclosed database warning from sqlite3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,9 @@ filterwarnings = [
 
     # `flask.testing` accesses this attribute; remove when they have updated their code.
     "default:The '__version__' attribute is deprecated and will be removed in Werkzeug 3\\.1\\.:DeprecationWarning",
+
+    # Python 3.13 sqlite3 module
+    "default: unclosed database in <sqlite3.Connection object at 0x.*>:ResourceWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
The Python 3.13 sqlite3 module added a new warning which is being issued during testing.
I do not know if there is an actual fix.
