### PR TITLE
Set tox minversion

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 4.0
 envlist =
     py3{8,9,10,11,12}
     py3{8,12}-sqlalchemy1


### PR DESCRIPTION
Use the older minversion instead of min_version for tox 3 compatibility.
