### PR TITLE
Fixing 'Save and Continue Editing' URL in edit form

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,7 @@ Fixes:
 * Fix `translations_path` attribute when Flask-Admin is used with Flask-Babel
 * Some translation updates.
 * Date fields no longer override `widget` if set in `form_args`
+* “Save and Continue Editing” button no longer discards the “return URL” (allowing to retain filters when switching back to the list)
 
 2.0.0a0
 -------

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -2298,7 +2298,9 @@ class BaseModelView(BaseView, ActionsMixin):
                     return redirect(self.get_url(".create_view", url=return_url))
                 elif "_continue_editing" in request.form:
                     return redirect(
-                        self.get_url(".edit_view", id=self.get_pk_value(model))
+                        self.get_url(
+                            ".edit_view", id=self.get_pk_value(model), url=return_url
+                        )
                     )
                 else:
                     # save button

--- a/flask_admin/tests/test_model.py
+++ b/flask_admin/tests/test_model.py
@@ -190,7 +190,7 @@ def test_mockview(app, admin):
     dispatched_client = Client(dispatched_app)
 
     rv = dispatched_client.post(
-        "/dispatched/admin/model/edit/?id=3",
+        "/dispatched/admin/model/edit/?id=3&url=/dispatched/admin/model/?flt0_filter%3Dvalue",
         data=dict(
             col1="another test!", col2="test@", col3="test#", _continue_editing="True"
         ),
@@ -205,7 +205,9 @@ def test_mockview(app, admin):
         headers = rv.headers
 
     assert status == "302 FOUND"
-    assert headers["Location"].endswith("/dispatched/admin/model/edit/?id=3")
+    assert headers["Location"].endswith(
+        "/dispatched/admin/model/edit/?id=3&url=/dispatched/admin/model/?flt0_filter%3Dvalue",
+    )
     model = view.updated_models.pop()
     assert model.col1 == "another test!"
 


### PR DESCRIPTION
fixes #2311

Action:
![action](https://github.com/user-attachments/assets/bf711e3d-9922-4f90-8997-11980d81bda5)

Before the fix (note the URL in location bar):
![before](https://github.com/user-attachments/assets/367011b8-e93e-4bee-ab5e-ac703157335d)

After the fix
![after](https://github.com/user-attachments/assets/fd0a6add-d8af-497c-aa08-726f9bfe8c62)
