### PR TITLE
Publish constructor docstrings

### DIFF
--- a/doc/api/mod_form_rules.rst
+++ b/doc/api/mod_form_rules.rst
@@ -4,34 +4,19 @@
 .. automodule:: flask_admin.form.rules
 
 	.. autoclass:: BaseRule
-		:members: __init__
 
 	.. autoclass:: NestedRule
-		:members: __init__
 
 	.. autoclass:: Text
-		:members: __init__
-
 
 	.. autoclass:: HTML
-		:members: __init__
-
 
 	.. autoclass:: Macro
-		:members: __init__
-
 
 	.. autoclass:: Container
-		:members: __init__
-
 
 	.. autoclass:: Field
-		:members: __init__
-
 
 	.. autoclass:: Header
-		:members: __init__
-
 
 	.. autoclass:: FieldSet
-		:members: __init__

--- a/doc/api/mod_form_upload.rst
+++ b/doc/api/mod_form_upload.rst
@@ -4,10 +4,13 @@
 .. automodule:: flask_admin.form.upload
 
 	.. autoclass:: FileUploadField
+		:class-doc-from: class
 		:members: __init__
 
 	.. autoclass:: ImageUploadField
+		:class-doc-from: class
 		:members: __init__
 
 	.. autoclass:: FileUploadInput
+
 	.. autoclass:: ImageUploadInput

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -95,6 +95,11 @@ add_module_names = False
 # modindex_common_prefix = []
 
 
+# -- sphinx.ext.autodoc Configuration ------------------------------------------
+
+autoclass_content = "both"
+
+
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
There is a lot of info in `__init__` docstrings that is not published with Sphinx. This changes that using `autoclass_content = 'both'`.

There are some instances in https://flask-admin.readthedocs.io/en/latest/api/mod_form_rules/ where there is duplication between the class signature and `__init__`, fix that.

And in https://flask-admin.readthedocs.io/en/latest/api/mod_form_upload/ the `__init__` and class signatures are different so need both.
