### PR TITLE
Fixes for bootstrap4/admin/lib.html

### DIFF
--- a/flask_admin/templates/bootstrap4/admin/actions.html
+++ b/flask_admin/templates/bootstrap4/admin/actions.html
@@ -2,7 +2,7 @@
 
 {% macro dropdown(actions, btn_class='nav-link dropdown-toggle') -%}
     <a class="{{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)" role="button" aria-haspopup="true"
-       aria-expanded="false">{{ _gettext('With selected') }}<b class="caret"></b></a>
+       aria-expanded="false">{{ _gettext('With selected') }}</a>
     <div class="dropdown-menu">
         {% for p in actions %}
             <a class="dropdown-item" href="javascript:void(0)"

--- a/flask_admin/templates/bootstrap4/admin/lib.html
+++ b/flask_admin/templates/bootstrap4/admin/lib.html
@@ -120,9 +120,9 @@
   {% set prepend = kwargs.pop('prepend', None) %}
   {% set append = kwargs.pop('append', None) %}
   <div class="form-group {{ kwargs.get('column_class', '') }}">
-    <label for="{{ field.id }}" class="control-label {% if field.widget.input_type == 'checkbox' %}d-block mb-0{% endif %}">{{ field.label.text }}
+    <label for="{{ field.id }}" class="col-form-label {% if field.widget.input_type == 'checkbox' %}d-block mb-0{% endif %}">{{ field.label.text }}
         {% if h.is_required_form_field(field) %}
-          <strong class="text-danger"">&#42;</strong>
+          <strong class="text-danger">&#42;</strong>
         {%- else -%}
           &nbsp;
         {%- endif %}

--- a/flask_admin/templates/bootstrap4/admin/model/inline_field_list.html
+++ b/flask_admin/templates/bootstrap4/admin/model/inline_field_list.html
@@ -4,7 +4,7 @@
     {{ field }}
 
     {% if h.is_field_error(field.errors) %}
-    <ul class="help-block input-errors">
+    <ul class="form-text input-errors">
       {% for e in field.errors if e is string %}
         <li>{{ e }}</li>
       {% endfor %}

--- a/flask_admin/templates/bootstrap4/admin/model/layout.html
+++ b/flask_admin/templates/bootstrap4/admin/model/layout.html
@@ -1,5 +1,5 @@
 {% macro filter_options(btn_class='dropdown-toggle') %}
-    <a class="nav-link {{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)">{{ _gettext('Add Filter') }}<b class="caret"></b></a>
+    <a class="nav-link {{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)">{{ _gettext('Add Filter') }}</a>
     <div class="dropdown-menu field-filters">
         {% for k in filter_groups %}
             <a href="javascript:void(0)" class="dropdown-item filter" onclick="return false;">{{ k }}</a>
@@ -11,7 +11,7 @@
     {% if admin_view.export_types|length > 1 %}
         <li class="dropdown">
             <a class="nav-link {{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)" role="button"
-               aria-haspopup="true" aria-expanded="false">{{ _gettext('Export') }}<b class="caret"></b></a>
+               aria-haspopup="true" aria-expanded="false">{{ _gettext('Export') }}</a>
             <div class="dropdown-menu">
                 {% for export_type in admin_view.export_types %}
                     <a class="dropdown-item"
@@ -99,7 +99,7 @@
 
 {% macro page_size_form(generator, page_size_options, btn_class='nav-link dropdown-toggle') %}
     <a class="{{ btn_class }}" data-toggle="dropdown" href="javascript:void(0)">
-        {{ page_size }} {{ _gettext('items') }}<b class="caret"></b>
+        {{ page_size }} {{ _gettext('items') }}
     </a>
     <div class="dropdown-menu">
       {% for option in page_size_options %}


### PR DESCRIPTION
Bootstrap 4 renamed .control-label to .col-form-label. https://getbootstrap.com/docs/4.0/migration/#forms-1

---

The original fix commit from #2532 