### PR TITLE
Fix SQLAlchemy 2 installed by sqlalchemy1 tox factor

### DIFF
--- a/requirements-skip/constraints-sqlalchemy1.txt
+++ b/requirements-skip/constraints-sqlalchemy1.txt
@@ -1,1 +1,0 @@
-sqlalchemy<2

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ setenv =
     SQLALCHEMY_SILENCE_UBER_WARNING = 1
     AZURE_STORAGE_CONNECTION_STRING = DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 deps =
-    sqlalchemy1: -c requirements-skip/constraints-sqlalchemy1.txt
+    sqlalchemy1: sqlalchemy<2
     -r requirements/tests.txt
 commands_pre =
     noflaskbabel: pip uninstall -y flask-babel


### PR DESCRIPTION
With use_frozen_constraints constraints are generated by calling "pip freeze" after the environment deps have been installed and before the package dependencies are installed, thus constraints-sqlalchemy1.txt is being ignored.

---

From #2518, but probably deserves it own PR.

From the logs for a sqlalchemy1 workflow run:

```
py312-sqlalchemy1: arrow==1.3.0,astroid==3.2.4,azure-common==1.1.28,azure-storage-blob==2.1.0,azure-storage-common==2.1.0,babel==2.16.0,beautifulsoup4==4.12.3,blinker==1.8.2,boto==2.49.0,certifi==2024.8.30,cffi==1.17.1,charset-normalizer==3.4.0,click==8.1.7,colour==0.1.5,coverage==7.6.1,cryptography==43.0.1,dill==0.3.8,dnspython==2.7.0,email_validator==2.2.0,exceptiongroup==1.2.2,flake8==7.1.1,Flask==3.0.3,Flask-Admin @ file:///home/runner/work/flask-admin/flask-admin/.tox/.tmp/package/1/flask_admin-2.0.0a0-py3-none-any.whl#sha256=be063b3a346085a903c97eec22d233cdf10ebac528d59793160728c057dfcfe5,flask-babel==4.0.0,Flask-SQLAlchemy==3.1.1,GeoAlchemy2==0.15.2,greenlet==3.1.1,idna==3.10,iniconfig==2.0.0,isort==5.13.2,itsdangerous==2.2.0,Jinja2==3.1.4,MarkupSafe==3.0.1,mccabe==0.7.0,numpy==2.1.2,packaging==24.1,peewee==3.17.6,pillow==10.4.0,pip==24.2,platformdirs==4.2.2,pluggy==1.5.0,psycopg2==2.9.9,pycodestyle==2.12.1,pycparser==2.22,pyflakes==3.2.0,pylint==3.2.7,pymongo==4.10.1,pytest==8.3.2,pytest-cov==5.0.0,python-dateutil==2.9.0.post0,pytz==2024.2,redis==5.1.1,requests==2.32.3,shapely==2.0.6,six==1.16.0,soupsieve==2.6,
SQLAlchemy==2.0.35
```