### PR TITLE
Switch to hatchling and exclude tests from installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,11 +79,11 @@ Source = "https://github.com/pallets-eco/flask-admin/"
 Chat = "https://discord.gg/pallets"
 
 [build-system]
-requires = ["flit_core<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.flit.module]
-name = "flask_admin"
+[tool.hatch.build.targets.wheel]
+exclude = ["flask_admin/tests"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
We're installing all the tests into site-packages.

I've checked and with flit-core you have to move the tests directory out of the package directory, and that is not going to change.

That would mean a bunch of changes. 

Instead switch to hatchling. The tests are still included in the sdist for those (distros) that want them but not installed for ordinary usage.
