### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,15 +22,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12']
         tox: ['normal']
         include:
-          - python: '3.8'
-            tox: 'py38-min'
+          - python: '3.9'
+            tox: 'py39-min'
           - python: '3.12'
             tox: 'py312-noflaskbabel'
-          - python: '3.8'
-            tox: 'py38-sqlalchemy1'
+          - python: '3.9'
+            tox: 'py39-sqlalchemy1'
           - python: '3.12'
             tox: 'py312-sqlalchemy1'
     services:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Breaking changes:
 
+* Removed support for Python 3.8.
 * Use of the `boto` library has been replaced by `boto3`. S3FileAdmin and S3Storage now accept an `s3_client` parameter taking a `boto3.client('s3')` instance rather than `aws_access_key_id`, `aws_secret_access_key`, and `region` parameters.
 
 2.0.0a1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,7 +39,7 @@ in the `examples` directory.
 Support
 -------
 
-Python 3.8 or higher.
+Python 3.9 or higher.
 
 Indices And Tables
 ------------------

--- a/examples/datetime-timezone/app.py
+++ b/examples/datetime-timezone/app.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from flask import Flask
 from flask import jsonify
@@ -14,7 +15,6 @@ from sqlalchemy import String
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
-from zoneinfo import ZoneInfo
 
 
 # model

--- a/flask_admin/_types.py
+++ b/flask_admin/_types.py
@@ -1,7 +1,6 @@
+from collections.abc import Sequence
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import Sequence
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -10,4 +9,4 @@ if TYPE_CHECKING:
 
 T_COLUMN_LIST = Sequence[Union[str, "sqlalchemy.Column"]]
 T_FORMATTER = Callable[[Any, Any, Any], Any]
-T_FORMATTERS = Dict[type, T_FORMATTER]
+T_FORMATTERS = dict[type, T_FORMATTER]

--- a/flask_admin/blueprints.py
+++ b/flask_admin/blueprints.py
@@ -38,7 +38,7 @@ class _BlueprintWithHostSupport(FlaskBlueprint):
         # endpoints.
         @self.url_defaults
         def inject_admin_routes_host_if_required(
-            endpoint: str, values: t.Dict[str, t.Any]
+            endpoint: str, values: dict[str, t.Any]
         ) -> None:
             if app.url_map.is_endpoint_expecting(
                 endpoint, ADMIN_ROUTES_HOST_VARIABLE_NAME
@@ -50,7 +50,7 @@ class _BlueprintWithHostSupport(FlaskBlueprint):
         # required by any of them.
         @self.url_value_preprocessor
         def strip_admin_routes_host_from_static_endpoint(
-            endpoint: t.Optional[str], values: t.Optional[t.Dict[str, t.Any]]
+            endpoint: t.Optional[str], values: t.Optional[dict[str, t.Any]]
         ) -> None:
             if (
                 endpoint

--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -2,10 +2,7 @@ import inspect
 import logging
 import warnings
 from typing import cast as t_cast
-from typing import Dict
-from typing import List
 from typing import Optional
-from typing import Tuple
 
 from flask import current_app
 from flask import flash
@@ -285,7 +282,7 @@ class ModelView(BaseModelView):
 
     column_type_formatters = DEFAULT_FORMATTERS  # type: ignore[assignment]
 
-    form_choices: Optional[Dict[str, List[Tuple[str, str]]]] = None
+    form_choices: Optional[dict[str, list[tuple[str, str]]]] = None
     """
         Map choices to form fields
 

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 from math import ceil
 from typing import cast
 from typing import Optional
-from typing import Type
 
 from flask import abort
 from flask import current_app
@@ -577,7 +576,7 @@ class BaseModelView(BaseView, ActionsMixin):
         prev/next pager buttons.
     """
 
-    form: Optional[Type[Form]] = None
+    form: Optional[type[Form]] = None
     """
         Form class. Override if you want to use custom form for your model.
         Will completely disable form scaffolding functionality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,12 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Topic :: Software Development :: Libraries :: Python Modules',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "flask>=2.0",
     "jinja2>=3.0",
@@ -117,7 +116,7 @@ source = ["flask_admin", "tests"]
 source = ["flask_admin", "*/site-packages"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 files = ["flask_admin"]
 show_error_codes = true
 pretty = true
@@ -174,7 +173,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 include = ["flask_admin", "tests"]
 typeCheckingMode = "basic"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 minversion = 4.0
 envlist =
-    py3{8,9,10,11,12}
-    py3{8,12}-sqlalchemy1
+    py3{9,10,11,12}
+    py3{9,12}-sqlalchemy1
     py312-noflaskbabel  # only tested against latest of all configurations, sans flask-babel
-    py38-min
+    py39-min
     style
     typing
     docs
@@ -29,7 +29,7 @@ commands =
     pip freeze
     pytest -v --tb=short --basetemp={envtmpdir} flask_admin/tests {posargs}
 
-[testenv:py38-min]
+[testenv:py39-min]
 deps = -r requirements-skip/tests-min.txt
 commands =
     pip freeze
@@ -43,7 +43,7 @@ commands = pre-commit run --all-files
 [testenv:typing]
 deps = -r requirements/typing.txt
 commands =
-    mypy --python-version 3.8
+    mypy --python-version 3.9
     mypy --python-version 3.12
 
 [testenv:docs]


### PR DESCRIPTION
[Python 3.8 went EOL at on 7th October 2024](https://devguide.python.org/versions/).

We can/should remove support for it.