### PR TITLE
Update pull_request_template.md with right changelog filename

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,6 @@ Ensure each step in the contributing guide is complete, especially the following
 - Add tests that demonstrate the correct behavior of the change. Tests
   should fail without the change.
 - Add or update relevant docs, in the docs folder and in code.
-- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
+- Add an entry in changelog.rst summarizing the change and linking to the issue.
 - Add `.. versionchanged::` entries in any relevant code docs.
 -->


### PR DESCRIPTION
I was trying to follow the PR steps, but CHANGES.rst does not exist in this repo, docs/changelog.rst does. So I've modified the PR description, but another approach is to rename changelog.rst to CHANGES.rst. I'm not sure the implications for changes being properly picked up by dependabot and such, however.