### PR TITLE
Update .gitignore with .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ flask_admin/tests/tmp
 dist/*
 make.bat
 venv
+.venv
 *.sublime-*
 .coverage
 __pycache__


### PR DESCRIPTION
Both the README and Python docs use venv, so I suggest adding it to gitignore so folks dont accidentally check in.