### PR TITLE
Add editable tip and docs typo fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ should be included, feel free to make the changes and submit a *pull-request*.
 
 To build the docs in your local environment, from the project directory:
 
-    tox -e docs-html
+```bash
+tox -e docs
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ pip install .
 If you are contributing a bug fix or a new feature, you can install the app in editable mode:
 
 ```shell
-pip install -e .
+pip install -e ".[all]"
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -104,14 +104,24 @@ To build the docs in your local environment, from the project directory:
 
 To install Flask-Admin, simply:
 
-    pip install flask-admin
+```shell
+pip install flask-admin
+```
 
 Or alternatively, you can download the repository and install manually
 by doing:
 
-    git clone https://github.com/pallets-eco/flask-admin.git
-    cd flask-admin
-    pip install .
+```shell
+git clone https://github.com/pallets-eco/flask-admin.git
+cd flask-admin
+pip install .
+```
+
+If you are contributing a bug fix or a new feature, you can install the app in editable mode:
+
+```shell
+pip install -e .
+```
 
 ## Tests
 


### PR DESCRIPTION
To help contributors out who don't understand why they don't see their changes taking effect, I've added a tip about how to install in editable mode. I didn't include the extras, but that should okay if they're not changing the extras (i.e. the extras will be there from the example installation).

I also added backticks as the Markdown lint VS Code extension recommends it, and it leads to better syntax highlighting in VS Code. But I can remove if you prefer indented style. The README currently uses a mix.