### PR TITLE
Update pyproject.toml testpaths directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ build-backend = "flit_core.buildapi"
 name = "flask_admin"
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["flask_admin/tests"]
 markers = [
     "flask_babel: requires Flask-Babel to be installed"
 ]


### PR DESCRIPTION
Pytest can't find the tests when it's specified as "tests", since it's under flask_admin. This fixes that.

It's possible that coverage.run also needs an update? I haven't tried it yet:

[tool.coverage.run]
branch = true
source = ["flask_admin", "tests"]