### PR TITLE
The security context needs a theme attribute

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -170,6 +170,7 @@ Defining a `security_context_processor` function will take care of this for you:
         return dict(
             admin_base_template=admin.theme.base_template,
             admin_view=admin.index_view,
+            theme=admin.theme,
             h=admin_helpers,
         )
 


### PR DESCRIPTION
To use the new version of Flask-Security not only `admiin.base_template` must be replaced by `armin.theme.base_template` but the context dictionary must contain a `theme` attribute that should point to `admin.theme`.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in changelog.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
