### PR TITLE
fixed error caused by the fallback implementation of gettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flask-Admin
 
-Flask-Admin is now part of Pallets-Eco, an open source organization managed by the 
+Flask-Admin is now part of Pallets-Eco, an open source organization managed by the
 Pallets team to facilitate community maintenance of Flask extensions. Please update
 your references to `https://github.com/pallets-eco/flask-admin.git`.
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ Fixes:
 
 * Jinja templates can now be loaded in StrictUndefined mode.
 * Remove an implicit dependency on `packaging`
+* Fixed an error caused by the fallback implementation of `gettext()` (when used in templates)
 
 2.0.0a2
 -------

--- a/flask_admin/babel.py
+++ b/flask_admin/babel.py
@@ -4,11 +4,11 @@ try:
 except ImportError:
 
     def gettext(string, **variables):
-        return string % variables
+        return string if not variables else string % variables
 
     def ngettext(singular, plural, num, **variables):
         variables.setdefault("num", num)
-        return (singular if num == 1 else plural) % variables
+        return gettext((singular if num == 1 else plural), **variables)
 
     def lazy_gettext(string, **variables):
         return gettext(string, **variables)


### PR DESCRIPTION
Turns out that when used with keywords _in templates_, `gettext()` gets invoked by Jinja _**without**_ keyword params (guess they're applied to the returned string instead). Thus, the current fallback implementation causes an error in such a case.