### PR TITLE
Typo fix base.py: add forgotten closing quote (") to the message {Export type "<type>" is not supported.}

### DIFF
--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -2532,7 +2532,7 @@ class BaseModelView(BaseView, ActionsMixin):
                 response_data = getattr(ds, export_type)
         except (AttributeError, tablib.UnsupportedFormat):
             flash(
-                gettext('Export type "%(type)s not supported.', type=export_type),
+                gettext('Export type "%(type)s" is not supported.', type=export_type),
                 "error",
             )
             return redirect(return_url)


### PR DESCRIPTION
Typo (syntax) fix in flash message:
```py
flash(
  gettext('Export type "%(type)s not supported.', type=export_type),
  ...                  ^       ^
)
```