### PR TITLE
Fix crash on startup in `auth`, `auth-flask-login`, `sqla-association_proxy`, and `datatime-timezone` examples (#2609)

### DIFF
--- a/examples/auth-flask-login/app.py
+++ b/examples/auth-flask-login/app.py
@@ -11,6 +11,7 @@ from flask_admin import expose
 from flask_admin import helpers
 from flask_admin.contrib import sqla
 from flask_admin.theme import Bootstrap4Theme
+from flask_babel import Babel
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import check_password_hash
 from werkzeug.security import generate_password_hash
@@ -188,6 +189,8 @@ admin = admin.Admin(
 
 # Add view
 admin.add_view(MyModelView(User, db.session))
+
+babel = Babel(app)
 
 
 def build_sample_db():

--- a/examples/auth-flask-login/requirements.txt
+++ b/examples/auth-flask-login/requirements.txt
@@ -1,4 +1,4 @@
 # Install Flask-Admin with required extras from the root of the repository
-../..[sqlalchemy]
+../..[sqlalchemy,translation]
 
 Flask-Login>=0.3.0

--- a/examples/auth/app.py
+++ b/examples/auth/app.py
@@ -10,6 +10,7 @@ from flask import url_for
 from flask_admin import helpers as admin_helpers
 from flask_admin.contrib import sqla
 from flask_admin.theme import Bootstrap4Theme
+from flask_babel import Babel
 from flask_security import current_user
 from flask_security import RoleMixin
 from flask_security import Security
@@ -102,6 +103,8 @@ admin = flask_admin.Admin(
 # Add model views
 admin.add_view(MyModelView(Role, db.session))
 admin.add_view(MyModelView(User, db.session))
+
+babel = Babel(app)
 
 
 # define a context processor for merging flask-admin's template context into the

--- a/examples/auth/requirements.txt
+++ b/examples/auth/requirements.txt
@@ -1,4 +1,5 @@
 # Install Flask-Admin with required extras from the root of the repository
-../..[sqlalchemy-with-utils]
+../..[sqlalchemy-with-utils,translation]
 
+setuptools
 flask-security-too

--- a/examples/datetime-timezone/app.py
+++ b/examples/datetime-timezone/app.py
@@ -8,6 +8,7 @@ from flask import session
 from flask_admin import Admin
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.model import typefmt
+from flask_babel import Babel
 from flask_sqlalchemy import SQLAlchemy
 from markupsafe import Markup
 from sqlalchemy import DateTime
@@ -135,6 +136,8 @@ with app.app_context():
             endpoint="timezone_aware_article",
         )
     )
+
+    babel = Babel(app)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/datetime-timezone/requirements.txt
+++ b/examples/datetime-timezone/requirements.txt
@@ -1,2 +1,2 @@
-Flask-Admin
-flask-sqlalchemy
+# Install Flask-Admin with required extras from the root of the repository
+../..[sqlalchemy,translation]

--- a/examples/sqla-association_proxy/app.py
+++ b/examples/sqla-association_proxy/app.py
@@ -2,6 +2,7 @@ import flask_admin as admin
 from flask import Flask
 from flask_admin.contrib import sqla
 from flask_admin.theme import Bootstrap4Theme
+from flask_babel import Babel
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref
@@ -17,6 +18,8 @@ app.config["SECRET_KEY"] = "123456790"
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
 app.config["SQLALCHEMY_ECHO"] = True
 db = SQLAlchemy(app)
+
+babel = Babel(app)
 
 
 # Flask views

--- a/examples/sqla-association_proxy/requirements.txt
+++ b/examples/sqla-association_proxy/requirements.txt
@@ -1,1 +1,1 @@
-../..[sqlalchemy]
+../..[sqlalchemy,translation]


### PR DESCRIPTION
Fix crash on startup in `auth`, `auth-flask-login`, `sqla-association_proxy`, and `datatime-timezone` example (#2609) by registering `app` with `Babel`.