### PR TITLE
remove sqlalchemy import

### DIFF
--- a/flask_admin/_types.py
+++ b/flask_admin/_types.py
@@ -49,6 +49,7 @@ if t.TYPE_CHECKING:
     import sqlalchemy  # noqa
     from sqlalchemy import Column as T_SQLALCHEMY_COLUMN
     from sqlalchemy import Table as T_TABLE  # noqa
+    from sqlalchemy.orm import InstrumentedAttribute as T_INSTRUMENTED_ATTRIBUTE
     from sqlalchemy.orm import scoped_session as T_SQLALCHEMY_SESSION  # noqa
     from sqlalchemy.orm.query import Query
     from sqlalchemy.sql.selectable import Select
@@ -90,6 +91,7 @@ else:
     T_SQLALCHEMY_QUERY = t.Union[
         "sqlalchemy.sql.selectable.Select", "sqlalchemy.orm.query.Query"
     ]
+    T_INSTRUMENTED_ATTRIBUTE = "sqlalchemy.orm.InstrumentedAttribute"
     T_SQLALCHEMY_SESSION = "sqlalchemy.orm.scoped_session"
     T_REDIS = "redis.Redis"
     T_PEEWEE_QUERY_AJAX_MODEL_LOADER = (

--- a/flask_admin/_types.py
+++ b/flask_admin/_types.py
@@ -49,10 +49,12 @@ if t.TYPE_CHECKING:
     import sqlalchemy  # noqa
     from sqlalchemy import Column as T_SQLALCHEMY_COLUMN
     from sqlalchemy import Table as T_TABLE  # noqa
-    from sqlalchemy.orm import InstrumentedAttribute as T_INSTRUMENTED_ATTRIBUTE
+    from sqlalchemy.orm import InstrumentedAttribute as T_INSTRUMENTED_ATTRIBUTE  # noqa
     from sqlalchemy.orm import scoped_session as T_SQLALCHEMY_SESSION  # noqa
     from sqlalchemy.orm.query import Query
     from sqlalchemy.sql.selectable import Select
+    from sqlalchemy_utils import Choice as T_CHOICE
+    from sqlalchemy_utils import ChoiceType as T_CHOICE_TYPE
 
     T_SQLALCHEMY_QUERY = t.Union[Query, Select]
     from redis import Redis as T_REDIS  # noqa
@@ -88,6 +90,9 @@ else:
     T_PEEWEE_MODEL = "peewee.BaseModel"
     T_MONGO_CLIENT = "pymongo.MongoClient"
     T_TABLE = "sqlalchemy.Table"
+    T_CHOICE_TYPE = "sqlalchemy_utils.ChoiceType"
+    T_CHOICE = "sqlalchemy_utils.Choice"
+
     T_SQLALCHEMY_QUERY = t.Union[
         "sqlalchemy.sql.selectable.Select", "sqlalchemy.orm.query.Query"
     ]

--- a/flask_admin/contrib/sqla/form.py
+++ b/flask_admin/contrib/sqla/form.py
@@ -7,7 +7,6 @@ from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy.orm import ColumnProperty
 from sqlalchemy.orm import InstrumentedAttribute
-from sqlalchemy_utils import ChoiceType
 from wtforms import Field
 from wtforms import fields
 from wtforms import Form
@@ -28,6 +27,7 @@ from flask_admin.model.form import InlineModelConverterBase
 from flask_admin.model.form import ModelConverterBase
 from flask_admin.model.helpers import prettify_name
 
+from ..._types import T_CHOICE_TYPE
 from ..._types import T_FIELD_ARGS_FILTERS
 from ..._types import T_FIELD_ARGS_LABEL
 from ..._types import T_FIELD_ARGS_PLACES
@@ -622,7 +622,7 @@ def avoid_empty_strings(value: t.Any) -> t.Any:
     return value if value else None
 
 
-def choice_type_coerce_factory(type_: ChoiceType) -> t.Callable[[t.Any], t.Any]:
+def choice_type_coerce_factory(type_: T_CHOICE_TYPE) -> t.Callable[[t.Any], t.Any]:
     """
     Return a function to coerce a ChoiceType column, for use by Select2Field.
     :param type_: ChoiceType object

--- a/flask_admin/contrib/sqla/typefmt.py
+++ b/flask_admin/contrib/sqla/typefmt.py
@@ -1,17 +1,15 @@
-import sqlalchemy_utils
 from sqlalchemy.ext.associationproxy import _AssociationList
 from sqlalchemy.orm.collections import InstrumentedList
 
 from flask_admin._types import T_ARROW
+from flask_admin._types import T_CHOICE
 from flask_admin._types import T_MODEL_VIEW
 from flask_admin.model.typefmt import BASE_FORMATTERS
 from flask_admin.model.typefmt import EXPORT_FORMATTERS
 from flask_admin.model.typefmt import list_formatter
 
 
-def choice_formatter(
-    view: T_MODEL_VIEW, choice: sqlalchemy_utils.Choice, name: str
-) -> str:
+def choice_formatter(view: T_MODEL_VIEW, choice: T_CHOICE, name: str) -> str:
     """
     Return label of selected choice
     see https://sqlalchemy-utils.readthedocs.io/

--- a/flask_admin/model/base.py
+++ b/flask_admin/model/base.py
@@ -19,7 +19,6 @@ from flask import request
 from flask import stream_with_context
 from jinja2 import pass_context  # type: ignore[attr-defined]
 from jinja2.runtime import Context
-from sqlalchemy.orm import InstrumentedAttribute
 from typing_extensions import TypeGuard
 from werkzeug import Response
 from werkzeug.utils import secure_filename
@@ -30,6 +29,7 @@ from .._types import T_COLUMN_LIST
 from .._types import T_COLUMN_TYPE_FORMATTERS
 from .._types import T_FIELD_ARGS_VALIDATORS
 from .._types import T_FILTER
+from .._types import T_INSTRUMENTED_ATTRIBUTE
 from .._types import T_ORM_MODEL
 from .._types import T_QUERY_AJAX_MODEL_LOADER
 from .._types import T_RESPONSE
@@ -650,7 +650,9 @@ class BaseModelView(BaseView, ActionsMixin):
                 )
     """
 
-    form_columns: t.Optional[t.Collection[t.Union[str, InstrumentedAttribute]]] = None
+    form_columns: t.Optional[t.Collection[t.Union[str, T_INSTRUMENTED_ATTRIBUTE]]] = (
+        None
+    )
     """
         Collection of the model field names for the form. If set to `None` will
         get them from the model.


### PR DESCRIPTION
fixes https://github.com/pallets-eco/flask-admin/issues/2628 . due to https://github.com/pallets-eco/flask-admin/commit/7a51179a21b1c7ab92f7e89161200fbdf07d6a2c, sqlalchemy became a required library even if it is not listed in dependencies. Moving the import to `_types.py` under `TYPE_CHECKING` guard fixes the issue.