### PR TITLE
Fix `EnumFilter.clean()` method to handle enum members

### DIFF
--- a/flask_admin/contrib/sqla/filters.py
+++ b/flask_admin/contrib/sqla/filters.py
@@ -394,7 +394,10 @@ class EnumFilterInList(FilterInList):
     def clean(self, value: t.Any) -> t.Any:
         values = super().clean(value)
         if self.enum_class is not None:
-            values = [self.enum_class[val] for val in values]
+            values = [
+                v if isinstance(v, self.enum_class) else self.enum_class[v]
+                for v in values
+            ]
         return values
 
 
@@ -408,7 +411,10 @@ class EnumFilterNotInList(FilterNotInList):
     def clean(self, value: t.Any) -> t.Any:
         values = super().clean(value)
         if self.enum_class is not None:
-            values = [self.enum_class[val] for val in values]
+            values = [
+                v if isinstance(v, self.enum_class) else self.enum_class[v]
+                for v in values
+            ]
         return values
 
 


### PR DESCRIPTION
This PR updates the `clean()` method in `EnumFilterInList` and `EnumFilterNotInList` classes to check if the value is already an enum member before converting. This prevents errors when values are already enum members)

Fixes: #2645 