### PR TITLE
AI junk

### DIFF
--- a/flask_admin/contrib/sqla/view.py
+++ b/flask_admin/contrib/sqla/view.py
@@ -1336,7 +1336,17 @@ class ModelView(BaseModelView):
             Model id
         """
         session = _get_deprecated_session(self.session)
-        return session.get(self.model, tools.iterdecode(id))
+        id_parts = tools.iterdecode(id)
+
+        if isinstance(self._primary_key, tuple):
+            expected = len(self._primary_key)
+        else:
+            expected = 1
+
+        if len(id_parts) != expected:
+            return None
+
+        return session.get(self.model, id_parts)
 
     # Error handler
     def handle_view_exception(self, exc: Exception) -> bool:


### PR DESCRIPTION
Fixes #2915.

When a single-PK model receives an id containing a comma (e.g. ?id=1,2), iterdecode returns a 2-tuple which SQLAlchemy 2.x rejects in Session.get(), causing an unhandled HTTP 500.

This validates that the number of decoded ID parts matches the expected number of PK columns before calling session.get(). On mismatch, returns None which all callers already handle with a 'Record does not exist.' flash + redirect.

All existing tests pass (247 passed, 80 skipped).