### PR TITLE
Fix typo in comment

### DIFF
--- a/flask_admin/contrib/sqla/ajax.py
+++ b/flask_admin/contrib/sqla/ajax.py
@@ -89,7 +89,7 @@ class QueryAjaxModelLoader(AjaxModelLoader):
 
     def get_one(self, pk: t.Any) -> t.Any:
         session = _get_deprecated_session(self.session)
-        # prevent autoflush from occuring during populate_obj
+        # prevent autoflush from occurring during populate_obj
         with session.no_autoflush:
             return session.get(self.model, pk)
 


### PR DESCRIPTION
Small typo fix in a comment: "occuring" -> "occurring".

- `flask_admin/contrib/sqla/ajax.py`: "prevent autoflush from occuring" -> "... from occurring"
