### PR TITLE
fix(peewee): return None from ajax get_one() when no record matches

### DIFF
--- a/flask_admin/contrib/peewee/ajax.py
+++ b/flask_admin/contrib/peewee/ajax.py
@@ -1,5 +1,7 @@
 import typing as t
 
+from peewee import DoesNotExist
+
 from flask_admin._compat import as_unicode
 from flask_admin._compat import string_types
 from flask_admin.model.ajax import AjaxModelLoader
@@ -55,7 +57,10 @@ class QueryAjaxModelLoader(AjaxModelLoader):
         return (getattr(model, self.pk), as_unicode(model))
 
     def get_one(self, pk: t.Any) -> t.Any:
-        return self.model.get(**{self.pk: pk})
+        try:
+            return self.model.get(**{self.pk: pk})
+        except DoesNotExist:
+            return None
 
     def get_list(
         self, term: str, offset: int = 0, limit: int = DEFAULT_PAGE_SIZE

--- a/flask_admin/tests/peeweemodel/test_basic.py
+++ b/flask_admin/tests/peeweemodel/test_basic.py
@@ -1077,6 +1077,15 @@ def test_ajax_fk(app: Flask, db: peewee.SqliteDatabase, admin: Admin) -> None:
     mdl = loader.get_one(model.id)  # type: ignore[attr-defined]
     assert mdl.test1 == model.test1
 
+    # a missing pk is not an error: get_one returns None so AjaxSelectField
+    # can render with no selection rather than raising peewee's DoesNotExist
+    assert loader.get_one(999999) is None
+
+    with app.test_request_context("/admin/view/"):
+        form = view.create_form()
+        form.model1.process_formdata([as_unicode(999999)])  # type: ignore[attr-defined]
+        assert form.model1.data is None  # type: ignore[attr-defined]
+
     items = loader.get_list("fir")
     assert len(items) == 1
     assert items[0].id == model.id  # type: ignore[attr-defined, union-attr]


### PR DESCRIPTION
## Summary

`QueryAjaxModelLoader.get_one()` in the peewee backend called `self.model.get(...)`, which raises `DoesNotExist` when no row matches. `AjaxSelectField._get_data` already guards with `if model is not None`, so a form that still holds a deleted (or otherwise unmatched) pk crashed instead of rendering with no selection.

The sqla and mongoengine loaders already return `None` on a miss, and the same peewee pattern was fixed for `ModelView.get_one()` in #2939. This applies that change to the ajax loader left out of that PR.

```python
def get_one(self, pk):
    try:
        return self.model.get(**{self.pk: pk})
    except DoesNotExist:
        return None
```

Closes #2940.

## Test plan

- [x] `test_ajax_fk` now asserts `loader.get_one(999999) is None`
- [x] Creating a form and feeding a missing pk no longer raises; the field data stays `None`
- [x] Full peewee suite: `pytest flask_admin/tests/peeweemodel/` (13 passed)