### PR TITLE
fix(sqla): coerce primary key values to column types in get_query_for_ids

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Bugfixes:
 * ``BaseTimeBetweenFilter.validate()`` now returns ``False`` on invalid input instead of raising an exception.
 * Fix encoding for editing file in FileAdmin. Now it uses UTF-8 and accepts non-ASCII characters.
 * SQLAlchemy backend: ``conv_ARRAY`` now infers the array element's ``python_type`` and passes it through as the ``Select2TagsField`` ``coerce`` callable. Saving a Postgres ``ARRAY(Integer)`` / ``ARRAY(Float)`` column no longer fails with ``column "x" is of type integer[] but expression is of type text[]`` (closes #1724).
+* SQLAlchemy backend: ``get_query_for_ids()`` now coerces string IDs to their model primary key column type when a ``python_type`` is defined. Bulk delete of records with integer primary keys no longer fails on PostgreSQL with psycopg 3 (closes #2951).
 * Fix sorting arrow direction in admin list view. Now it reflects the current sorting state (closes #2933).
 * MongoEngine fileadmin backend: downloading GridFS files now preserves their name and extension instead of saving them as ``file`` (closes #2916).
 * MongoEngine backend: stop reading the deprecated ``GridOut.contentType`` property. File downloads and list/form widgets now resolve the MIME type via ``metadata["content_type"]``, the GridFS document directly (for legacy data), or filename-based guessing (closes #2920).

--- a/flask_admin/contrib/sqla/tools.py
+++ b/flask_admin/contrib/sqla/tools.py
@@ -127,6 +127,35 @@ def tuple_operator_in(
         return None
 
 
+def _coerce_pk_value(col: t.Any, val: t.Any) -> t.Any:
+    """
+    Coerce string value from HTTP request into the column's native python_type.
+    Falls back gracefully if python_type is not implemented or coercion fails.
+    """
+    try:
+        type_ = getattr(col, "type", None)
+        try:
+            python_type = getattr(type_, "python_type", None)
+        except NotImplementedError:
+            python_type = None
+
+        if python_type is not None:
+            if isinstance(val, python_type):
+                return val
+            if python_type is bool:
+                if isinstance(val, str):
+                    v = val.strip().lower()
+                    if v in ("true", "1", "t", "yes", "y"):
+                        return True
+                    elif v in ("false", "0", "f", "no", "n"):
+                        return False
+                    return val
+            return python_type(val)
+    except (NotImplementedError, AttributeError, ValueError, TypeError):
+        return val
+    return val
+
+
 def get_query_for_ids(
     modelquery: t.Any, model: type[T_SQLALCHEMY_MODEL], ids: tuple[str, ...]
 ) -> t.Any:
@@ -143,8 +172,22 @@ def get_query_for_ids(
         # Get model primary key property references
         model_pk = [getattr(model, name) for name in get_primary_key(model)]
 
+        coerced_decoded_ids = []
+        for key_tuple in decoded_ids:
+            if len(key_tuple) != len(model_pk):
+                raise ValueError(
+                    f"Mismatch between expected primary key count ({len(model_pk)}) "
+                    f"and input key fields ({len(key_tuple)})."
+                )
+            coerced_decoded_ids.append(
+                tuple(
+                    _coerce_pk_value(col, val)
+                    for col, val in zip(model_pk, key_tuple, strict=True)
+                )
+            )
+
         try:
-            query = modelquery.filter(tuple_(*model_pk).in_(decoded_ids))
+            query = modelquery.filter(tuple_(*model_pk).in_(coerced_decoded_ids))
             # Only the execution of the query will tell us, if the tuple_
             # operator really works
             query.all()
@@ -152,7 +195,7 @@ def get_query_for_ids(
             query = modelquery.filter(
                 tuple_operator_in(
                     model_pk,
-                    decoded_ids,  # type: ignore[arg-type]
+                    coerced_decoded_ids,  # type: ignore[arg-type]
                 )
             )
     else:
@@ -160,7 +203,8 @@ def get_query_for_ids(
             model,
             get_primary_key(model),  # type: ignore[arg-type]
         )
-        query = modelquery.filter(model_pk.in_(ids))
+        coerced_ids = [_coerce_pk_value(model_pk, v) for v in ids]
+        query = modelquery.filter(model_pk.in_(coerced_ids))
 
     return query
 

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -2547,7 +2547,57 @@ def test_multiple_delete(
         assert sqla_db_ext.db.session.query(M1).count() == 0
 
 
-def test_multiple_delete_uuid_pk(
+_u1, _u2, _u3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+
+@pytest.mark.parametrize(
+    ("col_type", "records", "delete_ids", "expected_remaining_id"),
+    [
+        (Integer, [1, 2, 3], ["1", "2"], 3),
+        (String(50), ["s1", "s2", "s3"], ["s1", "s2"], "s3"),
+        (UUIDType(binary=False), [_u1, _u2, _u3], [str(_u1), str(_u2)], _u3),
+    ],
+)
+def test_multiple_delete_standard_pks(
+    app: Flask,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    admin: Admin,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+    col_type: t.Any,
+    records: list[t.Any],
+    delete_ids: list[str],
+    expected_remaining_id: t.Any,
+) -> None:
+    with app.app_context():
+
+        class DynamicModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "dynamic_pk_model"
+            id = Column(col_type, primary_key=True)
+            name = Column(String(50))
+
+        sqla_db_ext.create_all()
+
+        sqla_db_ext.db.session.add_all(
+            [DynamicModel(id=val, name=f"name_{val}") for val in records]
+        )
+        sqla_db_ext.db.session.commit()
+
+        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        admin.add_view(ModelView(DynamicModel, param))
+        client = app.test_client()
+
+        rv = client.post(
+            "/admin/dynamicmodel/action/",
+            data=dict(action="delete", rowid=delete_ids),
+        )
+        assert rv.status_code == 302
+        assert sqla_db_ext.db.session.query(DynamicModel).count() == 1
+        remaining = sqla_db_ext.db.session.query(DynamicModel).first()
+        assert remaining is not None
+        assert remaining.id == expected_remaining_id
+
+
+def test_multiple_delete_boolean_pk(
     app: Flask,
     sqla_db_ext: T_ANY_SQLA_PROVIDER,
     admin: Admin,
@@ -2555,72 +2605,47 @@ def test_multiple_delete_uuid_pk(
 ) -> None:
     with app.app_context():
 
-        class UuidModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "uuid_model"
-            id = Column(UUIDType(binary=False), primary_key=True)
+        class BoolModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "bool_model_bulk_delete"
+            id = Column(Boolean, primary_key=True)
             name = Column(String(50))
 
         sqla_db_ext.create_all()
 
-        u1, u2, u3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
         sqla_db_ext.db.session.add_all(
             [
-                UuidModel(id=u1, name="a"),
-                UuidModel(id=u2, name="b"),
-                UuidModel(id=u3, name="c"),
+                BoolModel(id=False, name="f_row"),
+                BoolModel(id=True, name="t_row"),
             ]
         )
         sqla_db_ext.db.session.commit()
 
         param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
-        admin.add_view(ModelView(UuidModel, param))
+        admin.add_view(ModelView(BoolModel, param))
         client = app.test_client()
 
+        # "False" string must delete False record without affecting True record
         rv = client.post(
-            "/admin/uuidmodel/action/",
-            data=dict(action="delete", rowid=[str(u1), str(u2)]),
+            "/admin/boolmodel/action/",
+            data=dict(action="delete", rowid=["False"]),
         )
         assert rv.status_code == 302
-        assert sqla_db_ext.db.session.query(UuidModel).count() == 1
-        model = sqla_db_ext.db.session.query(UuidModel).first()
+        assert sqla_db_ext.db.session.query(BoolModel).count() == 1
+        model = sqla_db_ext.db.session.query(BoolModel).first()
         assert model is not None
-        assert model.id == u3
+        assert model.id == True  # noqa: E712
+        assert model.name == "t_row"
 
 
-def test_get_query_for_ids_coercion(
+def test_multiple_delete_type_decorator_pk(
     app: Flask,
     sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    admin: Admin,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
 ) -> None:
     with app.app_context():
-
-        class IntModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "int_model"
-            id = Column(Integer, primary_key=True)
-            name = Column(String(50))
-
-        class BoolModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "bool_model_coercion"
-            id = Column(Boolean, primary_key=True)
-            name = Column(String(50))
-
-        class UuidModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "uuid_model_coercion"
-            id = Column(UUIDType(binary=False), primary_key=True)
-            name = Column(String(50))
-
-        class StrModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "str_model"
-            id = Column(String(50), primary_key=True)
-            name = Column(String(50))
-
-        class CompositeModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "composite_model"
-            id1 = Column(Integer, primary_key=True)
-            id2 = Column(String(50), primary_key=True)
-            name = Column(String(50))
-
         if t.TYPE_CHECKING:
-            _HexIntBase = TypeDecorator[int]
+            _HexIntBase = TypeDecorator[str]
         else:
             _HexIntBase = TypeDecorator
 
@@ -2635,98 +2660,43 @@ def test_get_query_for_ids_coercion(
                     return int(value, 16)
                 return int(value)
 
+            def process_result_value(self, value: t.Any, dialect: t.Any) -> str | None:
+                if value is None:
+                    return None
+                return hex(value)[2:]
+
         class HexModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
-            __tablename__ = "hex_model"
+            __tablename__ = "hex_model_bulk_delete"
             id = Column(HexInt, primary_key=True)
             name = Column(String(50))
 
         sqla_db_ext.create_all()
 
-        u1 = uuid.uuid4()
-        sqla_db_ext.db.session.add_all(
-            [
-                IntModel(id=1, name="int1"),
-                BoolModel(id=False, name="f_row"),
-                BoolModel(id=True, name="t_row"),
-                UuidModel(id=u1, name="uuid1"),
-                StrModel(id="s1", name="str1"),
-                CompositeModel(id1=1, id2="c1", name="comp1"),
-                HexModel(id=16, name="hex16"),
-            ]
-        )
+        m1 = HexModel(id="10", name="hex16")
+        m2 = HexModel(id="20", name="hex32")
+        sqla_db_ext.db.session.add_all([m1, m2])
         sqla_db_ext.db.session.commit()
 
-        # 1. String to integer coercion: verifies parameter types fail without fix
-        q_int = tools.get_query_for_ids(
-            sqla_db_ext.db.session.query(IntModel), IntModel, ("1", "2")
-        )
-        assert q_int.count() == 1
-        compiled_int = q_int.statement.compile()
-        assert compiled_int.params["id_1"] == [1, 2]
-        assert all(isinstance(v, int) for v in compiled_int.params["id_1"])
+        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        view = CustomModelView(HexModel, param)
+        admin.add_view(view)
 
-        # 2. Boolean coercion: "False" string must coerce to False without deleting True
-        q_bool = tools.get_query_for_ids(
-            sqla_db_ext.db.session.query(BoolModel), BoolModel, ("False",)
-        )
-        compiled_bool = q_bool.statement.compile()
-        assert compiled_bool.params["id_1"] == [False]
-        assert q_bool.count() == 1
-        bool_row = q_bool.first()
-        assert bool_row is not None
-        assert bool_row.name == "f_row"
+        # Retrieve row ID generated by the view (simulating real page checkbox value)
+        row_id = view.get_pk_value(m1)
+        assert row_id == "10"
 
-        # 3. String to UUID coercion
-        q_uuid = tools.get_query_for_ids(
-            sqla_db_ext.db.session.query(UuidModel), UuidModel, (str(u1),)
-        )
-        assert q_uuid.count() == 1
-        compiled_uuid = q_uuid.statement.compile()
-        assert compiled_uuid.params["id_1"] == [u1]
-        assert all(isinstance(v, uuid.UUID) for v in compiled_uuid.params["id_1"])
+        client = app.test_client()
 
-        # 4. String remains string
-        q_str = tools.get_query_for_ids(
-            sqla_db_ext.db.session.query(StrModel), StrModel, ("s1",)
+        rv = client.post(
+            "/admin/hexmodel/action/",
+            data=dict(action="delete", rowid=[row_id]),
         )
-        assert q_str.count() == 1
-        compiled_str = q_str.statement.compile()
-        assert compiled_str.params["id_1"] == ["s1"]
-
-        # 5. Composite PK coerced respectively
-        comp_id = tools.iterencode([1, "c1"])
-        q_comp = tools.get_query_for_ids(
-            sqla_db_ext.db.session.query(CompositeModel),
-            CompositeModel,
-            (comp_id,),
-        )
-        assert q_comp.count() == 1
-
-        # 6. TypeDecorator without python_type preserves input string
-        # for its process_bind_param
-        q_hex = tools.get_query_for_ids(
-            sqla_db_ext.db.session.query(HexModel), HexModel, ("10",)
-        )
-        compiled_hex = q_hex.statement.compile()
-        assert compiled_hex.params["id_1"] == ["10"]
-        assert q_hex.count() == 1
-        hex_row = q_hex.first()
-        assert hex_row is not None
-        assert hex_row.name == "hex16"
-
-        # 7. Invalid string input falls back safely
-        q_fallback = tools.get_query_for_ids(
-            sqla_db_ext.db.session.query(IntModel), IntModel, ("invalid",)
-        )
-        assert q_fallback.count() == 0
-
-        # 8. Mismatched composite key length raises ValueError
-        with pytest.raises(ValueError):
-            tools.get_query_for_ids(
-                sqla_db_ext.db.session.query(CompositeModel),
-                CompositeModel,
-                (tools.iterencode([1, "c1", "extra"]),),
-            )
+        assert rv.status_code == 302
+        assert sqla_db_ext.db.session.query(HexModel).count() == 1
+        remaining = sqla_db_ext.db.session.query(HexModel).first()
+        assert remaining is not None
+        assert remaining.id == "20"
+        assert remaining.name == "hex32"
 
 
 def test_default_sort(

--- a/flask_admin/tests/sqla/test_basic.py
+++ b/flask_admin/tests/sqla/test_basic.py
@@ -24,6 +24,7 @@ from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import Text
 from sqlalchemy import Time
+from sqlalchemy import TypeDecorator
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
@@ -2539,10 +2540,193 @@ def test_multiple_delete(
         client = app.test_client()
 
         rv = client.post(
-            "/admin/model1/action/", data=dict(action="delete", rowid=[1, 2, 3])
+            "/admin/model1/action/",
+            data=dict(action="delete", rowid=["1", "2", "3"]),
         )
         assert rv.status_code == 302
         assert sqla_db_ext.db.session.query(M1).count() == 0
+
+
+def test_multiple_delete_uuid_pk(
+    app: Flask,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+    admin: Admin,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
+    with app.app_context():
+
+        class UuidModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "uuid_model"
+            id = Column(UUIDType(binary=False), primary_key=True)
+            name = Column(String(50))
+
+        sqla_db_ext.create_all()
+
+        u1, u2, u3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        sqla_db_ext.db.session.add_all(
+            [
+                UuidModel(id=u1, name="a"),
+                UuidModel(id=u2, name="b"),
+                UuidModel(id=u3, name="c"),
+            ]
+        )
+        sqla_db_ext.db.session.commit()
+
+        param = skip_or_return_session_or_db(sqla_db_ext, session_or_db)
+        admin.add_view(ModelView(UuidModel, param))
+        client = app.test_client()
+
+        rv = client.post(
+            "/admin/uuidmodel/action/",
+            data=dict(action="delete", rowid=[str(u1), str(u2)]),
+        )
+        assert rv.status_code == 302
+        assert sqla_db_ext.db.session.query(UuidModel).count() == 1
+        model = sqla_db_ext.db.session.query(UuidModel).first()
+        assert model is not None
+        assert model.id == u3
+
+
+def test_get_query_for_ids_coercion(
+    app: Flask,
+    sqla_db_ext: T_ANY_SQLA_PROVIDER,
+) -> None:
+    with app.app_context():
+
+        class IntModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "int_model"
+            id = Column(Integer, primary_key=True)
+            name = Column(String(50))
+
+        class BoolModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "bool_model_coercion"
+            id = Column(Boolean, primary_key=True)
+            name = Column(String(50))
+
+        class UuidModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "uuid_model_coercion"
+            id = Column(UUIDType(binary=False), primary_key=True)
+            name = Column(String(50))
+
+        class StrModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "str_model"
+            id = Column(String(50), primary_key=True)
+            name = Column(String(50))
+
+        class CompositeModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "composite_model"
+            id1 = Column(Integer, primary_key=True)
+            id2 = Column(String(50), primary_key=True)
+            name = Column(String(50))
+
+        if t.TYPE_CHECKING:
+            _HexIntBase = TypeDecorator[int]
+        else:
+            _HexIntBase = TypeDecorator
+
+        class HexInt(_HexIntBase):
+            impl = Integer
+            cache_ok = True
+
+            def process_bind_param(self, value: t.Any, dialect: t.Any) -> int | None:
+                if value is None:
+                    return None
+                if isinstance(value, str):
+                    return int(value, 16)
+                return int(value)
+
+        class HexModel(sqla_db_ext.Base):  # type: ignore[misc, name-defined]
+            __tablename__ = "hex_model"
+            id = Column(HexInt, primary_key=True)
+            name = Column(String(50))
+
+        sqla_db_ext.create_all()
+
+        u1 = uuid.uuid4()
+        sqla_db_ext.db.session.add_all(
+            [
+                IntModel(id=1, name="int1"),
+                BoolModel(id=False, name="f_row"),
+                BoolModel(id=True, name="t_row"),
+                UuidModel(id=u1, name="uuid1"),
+                StrModel(id="s1", name="str1"),
+                CompositeModel(id1=1, id2="c1", name="comp1"),
+                HexModel(id=16, name="hex16"),
+            ]
+        )
+        sqla_db_ext.db.session.commit()
+
+        # 1. String to integer coercion: verifies parameter types fail without fix
+        q_int = tools.get_query_for_ids(
+            sqla_db_ext.db.session.query(IntModel), IntModel, ("1", "2")
+        )
+        assert q_int.count() == 1
+        compiled_int = q_int.statement.compile()
+        assert compiled_int.params["id_1"] == [1, 2]
+        assert all(isinstance(v, int) for v in compiled_int.params["id_1"])
+
+        # 2. Boolean coercion: "False" string must coerce to False without deleting True
+        q_bool = tools.get_query_for_ids(
+            sqla_db_ext.db.session.query(BoolModel), BoolModel, ("False",)
+        )
+        compiled_bool = q_bool.statement.compile()
+        assert compiled_bool.params["id_1"] == [False]
+        assert q_bool.count() == 1
+        bool_row = q_bool.first()
+        assert bool_row is not None
+        assert bool_row.name == "f_row"
+
+        # 3. String to UUID coercion
+        q_uuid = tools.get_query_for_ids(
+            sqla_db_ext.db.session.query(UuidModel), UuidModel, (str(u1),)
+        )
+        assert q_uuid.count() == 1
+        compiled_uuid = q_uuid.statement.compile()
+        assert compiled_uuid.params["id_1"] == [u1]
+        assert all(isinstance(v, uuid.UUID) for v in compiled_uuid.params["id_1"])
+
+        # 4. String remains string
+        q_str = tools.get_query_for_ids(
+            sqla_db_ext.db.session.query(StrModel), StrModel, ("s1",)
+        )
+        assert q_str.count() == 1
+        compiled_str = q_str.statement.compile()
+        assert compiled_str.params["id_1"] == ["s1"]
+
+        # 5. Composite PK coerced respectively
+        comp_id = tools.iterencode([1, "c1"])
+        q_comp = tools.get_query_for_ids(
+            sqla_db_ext.db.session.query(CompositeModel),
+            CompositeModel,
+            (comp_id,),
+        )
+        assert q_comp.count() == 1
+
+        # 6. TypeDecorator without python_type preserves input string
+        # for its process_bind_param
+        q_hex = tools.get_query_for_ids(
+            sqla_db_ext.db.session.query(HexModel), HexModel, ("10",)
+        )
+        compiled_hex = q_hex.statement.compile()
+        assert compiled_hex.params["id_1"] == ["10"]
+        assert q_hex.count() == 1
+        hex_row = q_hex.first()
+        assert hex_row is not None
+        assert hex_row.name == "hex16"
+
+        # 7. Invalid string input falls back safely
+        q_fallback = tools.get_query_for_ids(
+            sqla_db_ext.db.session.query(IntModel), IntModel, ("invalid",)
+        )
+        assert q_fallback.count() == 0
+
+        # 8. Mismatched composite key length raises ValueError
+        with pytest.raises(ValueError):
+            tools.get_query_for_ids(
+                sqla_db_ext.db.session.query(CompositeModel),
+                CompositeModel,
+                (tools.iterencode([1, "c1", "extra"]),),
+            )
 
 
 def test_default_sort(

--- a/flask_admin/tests/sqla/test_multi_pk.py
+++ b/flask_admin/tests/sqla/test_multi_pk.py
@@ -73,11 +73,23 @@ def test_multiple_pk(
         assert rv.status_code == 500
         assert sqla_db_ext.db.session.query(Model).count() == 2
 
+        # Deleting selected composite PK record preserves unselected record
         encoded_id1 = tools.iterencode([1, "two"])
+        rv = client.post(
+            "/admin/model/action/",
+            data=dict(action="delete", rowid=[encoded_id1]),
+        )
+        assert rv.status_code == 302
+        assert sqla_db_ext.db.session.query(Model).count() == 1
+        remaining = sqla_db_ext.db.session.query(Model).first()
+        assert remaining is not None
+        assert remaining.id == 2
+        assert remaining.id2 == "three"
+
         encoded_id2 = tools.iterencode([2, "three"])
         rv = client.post(
             "/admin/model/action/",
-            data=dict(action="delete", rowid=[encoded_id1, encoded_id2]),
+            data=dict(action="delete", rowid=[encoded_id2]),
         )
         assert rv.status_code == 302
         assert sqla_db_ext.db.session.query(Model).count() == 0

--- a/flask_admin/tests/sqla/test_multi_pk.py
+++ b/flask_admin/tests/sqla/test_multi_pk.py
@@ -7,6 +7,7 @@ from sqlalchemy import Integer
 from sqlalchemy import String
 
 from ... import Admin
+from ...contrib.sqla import tools
 from ..conftest import skip_or_return_session_or_db
 from ..conftest import T_ANY_SQLA_PROVIDER
 from ..conftest import T_LITERAL_SESSION_OR_DB
@@ -55,6 +56,31 @@ def test_multiple_pk(
         # Correct order is mandatory -> fail here
         rv = client.get("/admin/model/edit/?id=two,1")
         assert rv.status_code == 302
+
+        # Bulk delete with multiple PKs
+        rv = client.post(
+            "/admin/model/new/", data=dict(id=2, id2="three", test="test4")
+        )
+        assert rv.status_code == 302
+        assert sqla_db_ext.db.session.query(Model).count() == 2
+
+        # Submitting mismatched composite PK fields must fail and not delete
+        encoded_mismatched = tools.iterencode([1, "two", "extra"])
+        rv = client.post(
+            "/admin/model/action/",
+            data=dict(action="delete", rowid=[encoded_mismatched]),
+        )
+        assert rv.status_code == 500
+        assert sqla_db_ext.db.session.query(Model).count() == 2
+
+        encoded_id1 = tools.iterencode([1, "two"])
+        encoded_id2 = tools.iterencode([2, "three"])
+        rv = client.post(
+            "/admin/model/action/",
+            data=dict(action="delete", rowid=[encoded_id1, encoded_id2]),
+        )
+        assert rv.status_code == 302
+        assert sqla_db_ext.db.session.query(Model).count() == 0
 
 
 def test_joined_inheritance(

--- a/flask_admin/tests/sqla/test_postgres.py
+++ b/flask_admin/tests/sqla/test_postgres.py
@@ -290,10 +290,11 @@ def sqla_postgres_psycopg3_db_ext(
         pytest.skip("psycopg (v3) is not installed")
 
     from sqlalchemy.dialects import registry
+    from sqlalchemy.exc import NoSuchModuleError
 
     try:
         registry.load("postgresql.psycopg")
-    except Exception:
+    except NoSuchModuleError:
         pytest.skip("SQLAlchemy dialect postgresql.psycopg is not available")
 
     base_uri = os.getenv(

--- a/flask_admin/tests/sqla/test_postgres.py
+++ b/flask_admin/tests/sqla/test_postgres.py
@@ -232,3 +232,42 @@ def test_boolean_filters(
         assert "true_val_1" in data
         assert "false_val_1" not in data
         assert "false_val_2" not in data
+
+
+def test_multiple_delete_integer_pk(
+    app: Flask,
+    sqla_postgres_db_ext: T_ANY_SQLA_PROVIDER,
+    postgres_admin: Admin,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
+    with app.app_context():
+
+        class IntModel(sqla_postgres_db_ext.Base):  # type: ignore[name-defined, misc]
+            __tablename__ = "test_bulk_delete_int_model"
+            id = Column(Integer, primary_key=True, autoincrement=True)
+            name = Column(String(50))
+
+        sqla_postgres_db_ext.drop_all()
+        sqla_postgres_db_ext.create_all()
+
+        m1 = IntModel(name="a")
+        m2 = IntModel(name="b")
+        m3 = IntModel(name="c")
+        sqla_postgres_db_ext.db.session.add_all([m1, m2, m3])
+        sqla_postgres_db_ext.db.session.commit()
+
+        param = skip_or_return_session_or_db(sqla_postgres_db_ext, session_or_db)
+        view = CustomModelView(IntModel, param)
+        postgres_admin.add_view(view)
+
+        client = app.test_client()
+
+        rv = client.post(
+            "/admin/intmodel/action/",
+            data=dict(action="delete", rowid=[str(m1.id), str(m2.id)]),
+        )
+        assert rv.status_code == 302
+        assert sqla_postgres_db_ext.db.session.query(IntModel).count() == 1
+        model = sqla_postgres_db_ext.db.session.query(IntModel).first()
+        assert model is not None
+        assert model.id == m3.id

--- a/flask_admin/tests/sqla/test_postgres.py
+++ b/flask_admin/tests/sqla/test_postgres.py
@@ -1,3 +1,7 @@
+import os
+import typing as t
+
+import pytest
 from citext import CIText
 from flask import Flask
 from sqlalchemy import Boolean
@@ -9,7 +13,10 @@ from sqlalchemy.dialects.postgresql import HSTORE
 from sqlalchemy.dialects.postgresql import JSON
 
 from ... import Admin
+from ..conftest import configure_sqla
 from ..conftest import skip_or_return_session_or_db
+from ..conftest import sqla_db_exts
+from ..conftest import SQLAProvider
 from ..conftest import T_ANY_SQLA_PROVIDER
 from ..conftest import T_LITERAL_SESSION_OR_DB
 from .test_basic import CustomModelView
@@ -269,5 +276,96 @@ def test_multiple_delete_integer_pk(
         assert rv.status_code == 302
         assert sqla_postgres_db_ext.db.session.query(IntModel).count() == 1
         model = sqla_postgres_db_ext.db.session.query(IntModel).first()
+        assert model is not None
+        assert model.id == m3.id
+
+
+@pytest.fixture(params=sqla_db_exts)
+def sqla_postgres_psycopg3_db_ext(
+    app: Flask, request: pytest.FixtureRequest
+) -> t.Generator[T_ANY_SQLA_PROVIDER, None, None]:
+    try:
+        import psycopg  # noqa: F401
+    except ImportError:
+        pytest.skip("psycopg (v3) is not installed")
+
+    from sqlalchemy.dialects import registry
+
+    try:
+        registry.load("postgresql.psycopg")
+    except Exception:
+        pytest.skip("SQLAlchemy dialect postgresql.psycopg is not available")
+
+    base_uri = os.getenv(
+        "SQLALCHEMY_DATABASE_URI",
+        "postgresql://postgres:postgres@localhost/flask_admin_test",
+    )
+    if "://" in base_uri:
+        _, rest = base_uri.split("://", 1)
+        uri = f"postgresql+psycopg://{rest}"
+    else:
+        uri = "postgresql+psycopg://postgres:postgres@localhost/flask_admin_test"
+
+    configure_sqla(app, uri, request)
+    provider_class = request.param
+    if provider_class != SQLAProvider:
+        provider = provider_class(engine_options={})
+    else:
+        provider = provider_class()
+
+    provider.db.init_app(app)
+
+    with app.app_context():
+        try:
+            yield provider
+        finally:
+            provider.db.session.close()
+            if hasattr(provider.db, "engine"):
+                provider.db.engine.dispose()
+            elif hasattr(provider.db, "engines"):
+                engines = getattr(provider.db, "_engines", None) or getattr(
+                    provider.db, "engines", {}
+                )
+                for eng in engines.values():
+                    eng.dispose()
+
+
+def test_multiple_delete_integer_pk_psycopg3(
+    app: Flask,
+    sqla_postgres_psycopg3_db_ext: T_ANY_SQLA_PROVIDER,
+    postgres_admin: Admin,
+    session_or_db: T_LITERAL_SESSION_OR_DB,
+) -> None:
+    with app.app_context():
+
+        class IntModel(sqla_postgres_psycopg3_db_ext.Base):  # type: ignore[name-defined, misc]
+            __tablename__ = "test_bulk_delete_int_model_psycopg3"
+            id = Column(Integer, primary_key=True, autoincrement=True)
+            name = Column(String(50))
+
+        sqla_postgres_psycopg3_db_ext.drop_all()
+        sqla_postgres_psycopg3_db_ext.create_all()
+
+        m1 = IntModel(name="a")
+        m2 = IntModel(name="b")
+        m3 = IntModel(name="c")
+        sqla_postgres_psycopg3_db_ext.db.session.add_all([m1, m2, m3])
+        sqla_postgres_psycopg3_db_ext.db.session.commit()
+
+        param = skip_or_return_session_or_db(
+            sqla_postgres_psycopg3_db_ext, session_or_db
+        )
+        view = CustomModelView(IntModel, param)
+        postgres_admin.add_view(view)
+
+        client = app.test_client()
+
+        rv = client.post(
+            "/admin/intmodel/action/",
+            data=dict(action="delete", rowid=[str(m1.id), str(m2.id)]),
+        )
+        assert rv.status_code == 302
+        assert sqla_postgres_psycopg3_db_ext.db.session.query(IntModel).count() == 1
+        model = sqla_postgres_psycopg3_db_ext.db.session.query(IntModel).first()
         assert model is not None
         assert model.id == m3.id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ tests = [
     "moto",
     "botocore>=1.35",
     "psycopg2-binary",
+    "psycopg[binary]",
     "beautifulsoup4",
     "azure-storage-blob",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -671,7 +671,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -823,6 +823,7 @@ dev = [
     { name = "pallets-sphinx-themes" },
     { name = "pre-commit" },
     { name = "pre-commit-uv" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -858,6 +859,7 @@ tests = [
     { name = "flake8" },
     { name = "flask", extra = ["async"] },
     { name = "moto" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -871,6 +873,7 @@ typing = [
     { name = "flask-admin", extra = ["all"] },
     { name = "moto" },
     { name = "mypy" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -939,6 +942,7 @@ dev = [
     { name = "pallets-sphinx-themes" },
     { name = "pre-commit" },
     { name = "pre-commit-uv" },
+    { name = "psycopg", extras = ["binary"] },
     { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -970,6 +974,7 @@ tests = [
     { name = "flake8" },
     { name = "flask", extras = ["async"] },
     { name = "moto" },
+    { name = "psycopg", extras = ["binary"] },
     { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -983,6 +988,7 @@ typing = [
     { name = "flask-admin", extras = ["all"], editable = "." },
     { name = "moto" },
     { name = "mypy" },
+    { name = "psycopg", extras = ["binary"] },
     { name = "psycopg2-binary" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1883,6 +1889,86 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/cf/f0577fe9c08b67c3c203506a99c69bbcb2b357e46e2f5f5705878c1e466f/psycopg_binary-3.3.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd0faa2475ab254ad1b507430131cf7f7f0be927ffdc03c32ad3b33d2ef63f42", size = 4720887, upload-time = "2026-08-31T22:39:12.731Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c7/4449033137966e6c72595613a7b0660cb8be5087e3adaf8425e9e85c76a0/psycopg_binary-3.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0d8a4b7ae47f3381e2ded89891d2455b809f4afb7e5b58086844abb8cfa420ea", size = 4770016, upload-time = "2026-08-31T22:39:21.194Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c8/87fee9bb4ab25500d7f1e608411cc3025ee86b5ba37cec90b094a3f5a810/psycopg_binary-3.3.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:04f64b39830887c2c737b522cbfd6ad215d65e67ebfff674aa4cf21c02af487b", size = 5587115, upload-time = "2026-08-31T22:39:27.591Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e9/6b5a23e4e64c3f69f55d15d48586436e90c5c3fb589d9c969c1d2a76b559/psycopg_binary-3.3.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d06da67e9c687c6a6fdac9da4b17cbeb296ddd59bd01f6416ed4294bc57c5faf", size = 5259372, upload-time = "2026-08-31T22:39:34.186Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3c/bfcc638f6865998348fb94ecdad87751ca34ddd5c10ad8acafa099bcf14d/psycopg_binary-3.3.5-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:972cc28e943746e71ede254a4dfd1fdfcdd6dcadd6f375703849859f09377f24", size = 6853658, upload-time = "2026-08-31T22:39:41.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ee/0f5afd823875c56736ad0d4f88fdcb4375407cb01b61e5188f607714500d/psycopg_binary-3.3.5-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:553b5443cbc94fdb9b0e31b62acdf615e0780982d6b13752a15eb3d6c0dfd0d2", size = 5100080, upload-time = "2026-08-31T22:39:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/53/89/1bdab84b79d1b9fb5a4fb82abf7e2e0e19952b2f417c3ce7a1e24f6c00c1/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:fd5b047c9fd887b767d063845413e405f5de8ce1dc7a9d0da0637b77b836b469", size = 4619598, upload-time = "2026-08-31T22:39:52.158Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d1/a9f1a8c4b2fee79ff929fd94367619e4ab3bfe39ad2e3cb475bb1e1dfa07/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4901e5b9a31c230211a1871263b6594373bacd770b14ad9b14d349716cb69cbe", size = 4312051, upload-time = "2026-08-31T22:39:57.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/12/79f1ee831bca072053fad7e5623e3a569fdef3fc3df3fb815cc9b10a23db/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b981d25fc2dd13fa7328e40703ea8a03f3e9d855ec946431e96a23206d3b9fd", size = 4039401, upload-time = "2026-08-31T22:40:02.253Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/93/b786e6424684bd5e7b7d27729a93862a925d2c22af5d890272642aac42d8/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:39e70c8e3b5fad70e2970ea4cc502bf3b612018f128aa1c670f1fa78b9774543", size = 4344454, upload-time = "2026-08-31T22:40:06.832Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0d/ab385a58e0e8849ec3c598ca44163e102afc4893b0d71b83c4b577654a06/psycopg_binary-3.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:ae67072db949d0c094b747a8ec52ad0fa3c42b27842a5f746f3613d54dde3fba", size = 3664079, upload-time = "2026-08-31T22:40:14.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/67/ac6b3dfd2d495f8599f7179f8082af4b3be72caa44942ddb45e9613338eb/psycopg_binary-3.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c6bd84e4cf67930f26f015dec33f615472b9c5871d46408efe112dbc1bc021de", size = 4720383, upload-time = "2026-08-31T22:40:22.262Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/c3870c7e5ba6b4444e3e5401c79d5e83afe2c7045844eabb25d5b39adecb/psycopg_binary-3.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fdbeb38c9b7ca8fa57a7bda3802bedb62f4494ad3dd46c7dd36dc3f77fd5093f", size = 4768854, upload-time = "2026-08-31T22:40:26.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a2/04834fb8a2af14d42e48abeb61ace0a4fee2d6f516723d897cff16fce677/psycopg_binary-3.3.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:06de14ac978a2d53e864069fb5487075c6e3cfb0740f1bfd7017bc8b9942067f", size = 5588618, upload-time = "2026-08-31T22:40:36.524Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0d/2eed6e7f8c5ada9e08cbdca4b78083df12f5c2a8d13fa0c62cd6b2b1d762/psycopg_binary-3.3.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d8b66353b20e79bf7ac0a80f03ae97f522ccbbf909d687eec62f112e56c0276d", size = 5259471, upload-time = "2026-08-31T22:40:46.43Z" },
+    { url = "https://files.pythonhosted.org/packages/96/66/2347889e693502e8473a60b3defac0300829007275a21980a2197c200418/psycopg_binary-3.3.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af5084124fb2fd16557073822519dfe8c389636a16adef661a4c0c3918733171", size = 6851181, upload-time = "2026-08-31T22:40:52.939Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/11/039d7bbdc8ac28292a2fb9f54a7385116c7d31a3bf9c87e71eda154b32b9/psycopg_binary-3.3.5-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1344fd57a19737554670e67aecabd4fb37cd7937f2925840009645d641117e5a", size = 5098916, upload-time = "2026-08-31T22:40:57.505Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/01/5f77284d0c682106279da7d9e26527ae99f3241a91f0549b033c84441404/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2719fe19a4da752c4110cc767716d0a5bdb760d1153d89018bb7c9c61717bde5", size = 4617043, upload-time = "2026-08-31T22:41:04.555Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4a/c07000298ffa3eaf25a720a5fd4bc9326676e99712722ca1accb40071e66/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:893ce86a4b997f6ca1261a7826db2506727332a6ff66646fa7f024b39b5e630e", size = 4310458, upload-time = "2026-08-31T22:41:11.72Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0a/cc7da5bb2bed198354f8dcc7c5dab3f1473edf2b6a177c1e8ec3fa9841ea/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a5e45e4bb68656253ce5c7a344c0a425c293581eba954d7fd7c2e4b2dc9f3038", size = 4039320, upload-time = "2026-08-31T22:41:20.783Z" },
+    { url = "https://files.pythonhosted.org/packages/17/60/f65755f1ab74223b437f1d366f63915b6f5e1292234de47643f898c29faf/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ca8af7c0454cdce235d4aedcb5528857468f1490202d25e24fc7af40e176d563", size = 4342427, upload-time = "2026-08-31T22:41:27.068Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3c/6b1ea5b5544fa51ee6da8e99e96ca6a639ed1e0da2e335467893f14d3182/psycopg_binary-3.3.5-cp311-cp311-win_amd64.whl", hash = "sha256:7b443f943abfe35aa5a776630cea27c9348aa66659286cee0b99084332252080", size = 3665235, upload-time = "2026-08-31T22:41:30.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/83/ba396428a4fb6b70f0dd41315ad86a2c14441b7214afd47b2d49cb450b78/psycopg_binary-3.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25105f9b46bdf2a30fcb67f56976ed66f6855941ae16bc024192609b917d493c", size = 4700169, upload-time = "2026-08-31T22:41:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/b23c5978e55cf4effdc5a3e13a17d69a580a487993e01b7c3768dd24281c/psycopg_binary-3.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0249c3e960cdee686000eb77169fb6590105c05bacc37e057ccdffdcd8e6ebde", size = 4763037, upload-time = "2026-08-31T22:41:47.571Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d8/b41108bfe194b4098076c8b873b05ec2ca9582445eccfd9075970d7b948e/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5698ab5941a4d138c30fef858588e651fe7d583280cd6e41832825ad9e747750", size = 5546232, upload-time = "2026-08-31T22:41:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d1/0f244dfef389e52e9dc3056f2a9033d1f6901e97d24d9a9c8b836e32ab6b/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:682a17a57415c3ca1731eec018ed031f012ffcb81ba74806eb219cb396065672", size = 5227752, upload-time = "2026-08-31T22:42:03.776Z" },
+    { url = "https://files.pythonhosted.org/packages/31/88/a4781365f09807fb91435e2d00096f3f6ae5d06bce15ef3c3c385dc22772/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2a61e8147902771df7efe14062a3c8736347850d0d8befcf048235752504f2e", size = 6824658, upload-time = "2026-08-31T22:42:13.263Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f1/072c4a46287644694731b3e40fab120ebacf6d153cce7ebf7a5b208f5561/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f7e1e45aad410e20de45df2b159df68ff6c8dbf47a3501f806c4489b27f4ad2b", size = 5061439, upload-time = "2026-08-31T22:42:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/1776a95c16941b8bbce89407cc7cf9ea3fd557efb503a40873c9e2b6394f/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c09775c549b40b274206e1b043c5e5b5af39666e85c98382a30bd05d23ab677b", size = 4588586, upload-time = "2026-08-31T22:42:25.23Z" },
+    { url = "https://files.pythonhosted.org/packages/82/64/44ec87b9a74faebe966856307b65c0d35ee6321ce509cdd0e8d6a3f5338b/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:cf0e5e63ee86098299c673992053d556c489ba9ae6aca6cb6e24d16a8e0b09e6", size = 4265161, upload-time = "2026-08-31T22:42:31.864Z" },
+    { url = "https://files.pythonhosted.org/packages/24/88/cf181df5651395a80afc520f5fefac72beb035c0c9d58ab7fcc880c9b221/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c065531e8c1815276f50dbfa283e3a7f022671414cdda6fa9a16794dd53b28f9", size = 3998727, upload-time = "2026-08-31T22:42:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1e/c72a1107647db4bb3f534c7fe1b57b1957d9c099e795f5aa81f4a2e0c312/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:df9853b832b7b916e02ef68e0d5403a7dab2d5c1ddfe94f22b1b155eb862622f", size = 4310119, upload-time = "2026-08-31T22:42:46.403Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/452620608cafff164737e20b42ebffee8151b865ee171ba0d6692a560a44/psycopg_binary-3.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:35885e333020fc152d27bea1a494bef13b2e68f6fd92b6229015e93539152008", size = 3648197, upload-time = "2026-08-31T22:42:51.575Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1c/e718752cc63cf4e99e4a10fd36e3a3364dabdd0819484a24c0d79fbb9685/psycopg_binary-3.3.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6e85d50b87257fb117675a19ee59daa7bf9a57f6431500adf7059df799232ef4", size = 4704421, upload-time = "2026-08-31T22:42:59.564Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cf/a0e748e27c09b92738e4460582d121ba1908be3e36791e150f435e54b332/psycopg_binary-3.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5becd311f9af8d180bad372f51fb2252fd02cb2073056e2b170c9274f95fe7f", size = 4765054, upload-time = "2026-08-31T22:43:05.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/62/0cbac0266d56c94dd1f702d9af2b5d54bf80b6e658048f4f2c5bd63dd7e3/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:19e5bf9872dbd164c220567fd385ba2309c7d9df1541f78343510c6b0f36a1b7", size = 5547137, upload-time = "2026-08-31T22:43:11.768Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3a/73c6f8871f38fc07a9c0b4cbc9467beb116a2783cecf87dfa53900a396dc/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb3b3bffebfe07110730626e76238161124f35ac87b748d663316a28d22f58b0", size = 5227577, upload-time = "2026-08-31T22:43:20.767Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/9f17b9f4d297b774dc574199c4dcd02dadc32a00c4056265918de5c70635/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2111f880add40fb03c60556069ad68e884a0908a74d2debafc603caf93b73552", size = 6824606, upload-time = "2026-08-31T22:43:33.698Z" },
+    { url = "https://files.pythonhosted.org/packages/94/86/d84dadd94a004dbbb43ce0579f1f766fdc6b8cbef745090e24bea77b5283/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:40505676b1526b9ea387dace034040a8c8b0bcf984cd6bd4720a2ab15e813586", size = 5060854, upload-time = "2026-08-31T22:43:42.258Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d0/e5078be2c7d2490c0d6cd4cb7b3601aec44be2fa8b3fe927e9419b06004f/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5816472e3bb05615f33a741e0835043d1f4bf9709ff30d2f4aed71815cfc6b5e", size = 4589511, upload-time = "2026-08-31T22:43:50.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/08dfb5b18fa482e025864fd91a022310d0782c42e4cf5dda5d0e010b6790/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:358748fc4c8ccdc0e2bdf55420494930e19c3ade586ea9c3a6de3dad1f897311", size = 4268144, upload-time = "2026-08-31T22:43:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b9/cb01dc1d63f3241b49b2ca7fb9f98d0f5c76127f0dbb9440635a6ad0233e/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1ef2e498be47800f6202b9a2304c22646325ca6d54001b7c785bcfdb24a1e8ab", size = 4001036, upload-time = "2026-08-31T22:44:04.429Z" },
+    { url = "https://files.pythonhosted.org/packages/95/49/7c17dd832c05b380562ff2ff5f6ab2bcaeca8b7fff2c2b355854368a5bdb/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:88e01aa2e938a45655a8a5213fc3a44ba78cb4cab8a569b3e0bcb3d1d0eaba16", size = 4313112, upload-time = "2026-08-31T22:44:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2c/b0b2f887185d6a2ec0b3bef948cc07656d2d1a5d96fa7f2bb03f6ef06ca4/psycopg_binary-3.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:ba466011569297114449df9d523438e1adeedf3e4f31ffb78e897ec3fef3076b", size = 3647313, upload-time = "2026-08-31T22:44:19.139Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7f/4e2395da194558533bd9c31f35e4dc58ecbbae6a7176b0d2f72d629e8a51/psycopg_binary-3.3.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f8b132c7243ef5f503f0b6f986bf16d38a51b0df1c6ba2577743f128be03e3", size = 4712612, upload-time = "2026-08-31T22:44:25.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/94/fdb2093c8ccd7048449156db526ad746740cf34fe9c01e5dc1b7a7a8b257/psycopg_binary-3.3.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0cac998b9b1e82dec853d2e53b3d34d56a525cf231f9441a636cfd5992929a9", size = 4775139, upload-time = "2026-08-31T22:44:36.719Z" },
+    { url = "https://files.pythonhosted.org/packages/31/52/5195e87960715f7be2005761b72d56fce4e7757d5333fd40384f071c2de1/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:479b96fd78149cfa10369dc53fbfb89ee729be13146b584a23dbc7e164c0cf1e", size = 5556807, upload-time = "2026-08-31T22:44:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/42/2d616210a91e1327516ed5ae71961aaa31bb740e4a61d7190f2221685a40/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f45d77e398542ce0937d9fa3cd9d84e9c5fc6b34c50a66404ae840bada312750", size = 5236206, upload-time = "2026-08-31T22:44:47.943Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2e/e54b0d4cc263b3526e3728bb50a69660d5e79e52255ccd2a1a71e40e6f9a/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98a388509306e5e08a4203253ac52846bc1b034e5cbd0ae6da1211593cc28594", size = 6838066, upload-time = "2026-08-31T22:44:55.701Z" },
+    { url = "https://files.pythonhosted.org/packages/77/80/ec22a110f81a44c411965982097efeee86006bdd5a1f51f628318106c84c/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ab39e2794b95af61a2ff69e33e5ab6ac5df36e9ffea9a3b18e38b2aaca8c5ad5", size = 5072036, upload-time = "2026-08-31T22:45:02.838Z" },
+    { url = "https://files.pythonhosted.org/packages/93/55/7bc3c3ac769ab4fe0c619f2179b4aab3ae043f4d478283dd8279d24c0be4/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9c071bf78e5c2e6efa40bc9089a954d7b41221347a72f35c6bf2d8c96e632f75", size = 4604058, upload-time = "2026-08-31T22:45:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/8e7414f7dc10b2959e664330cdcf393e412f67355975dafa876cef265264/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:14fdfd65a96ecbd8b586d14546105641f4a6ac7cbe335c786830ea4de94bbe60", size = 4284766, upload-time = "2026-08-31T22:45:17.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/72/33f293c1d3ee9114f47e9ef4880f31c9de864e84a9b09454c26e106c25ed/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8dbd694f3741dd4ac5bc60b70e17f7841aefb3f0f38cef4d2756de270e03af43", size = 4011958, upload-time = "2026-08-31T22:45:24.792Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/8e38840e5a7d006987bbc9acb29951912253fa50549a4db92b3aa535f089/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:14f432430fd9e1a9e7d9ab2fe14956c77f5d074ebdc556a1ad04e9a1bd3fca04", size = 4323273, upload-time = "2026-08-31T22:45:32.973Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c7/b7ebf601c307f93e7c4c4ebac0edc9db3b2729ca038efe700a18f86b5517/psycopg_binary-3.3.5-cp314-cp314-win_amd64.whl", hash = "sha256:df209e64674a34b41662c67fdc8b4e0ffd77d2136393790691d086a09f9a6cab", size = 3745885, upload-time = "2026-08-31T22:45:40.537Z" },
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
@@ -2360,23 +2446,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -2391,23 +2477,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -2423,23 +2509,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [


### PR DESCRIPTION
Fixes #2951

### Problem
In the SQLAlchemy backend, bulk delete passes primary key IDs submitted from HTTP form actions as strings into `get_query_for_ids()`. When running on PostgreSQL with strict drivers like `psycopg` 3, filtering an integer primary key column with string IDs fails with:
```
operator does not exist: integer = character varying
```

### Solution
Coerce string primary key values to their column's `python_type` in `get_query_for_ids()` before constructing the filter. This ensures:
- Values match the column's expected type when binding parameters.
- Boolean primary keys correctly parse boolean strings without misinterpreting `"False"`.
- Custom `TypeDecorator` primary keys preserve their existing bind-parameter processing.
- Composite primary keys validate field counts against model columns.

### Testing & CI
- Consolidated standard primary key bulk delete tests across Integer, String, and UUID into a single parameterized behavioral test.
- Added behavioral tests for Boolean PK, custom TypeDecorator PK, and composite PK with mismatched field count validation.
- Added `psycopg[binary]` to test dependencies in `pyproject.toml` and updated `uv.lock` so PostgreSQL + `psycopg` 3 is automatically tested in CI on SQLAlchemy 2.
- Verified that on PostgreSQL with `psycopg` 3, the bulk delete test fails without this fix and passes with it.